### PR TITLE
fix: published toggle - copy link

### DIFF
--- a/apps/spaces/src/components/QuizViewLayout/index.tsx
+++ b/apps/spaces/src/components/QuizViewLayout/index.tsx
@@ -354,6 +354,7 @@ export const QuizViewLayout: FunctionComponent<Props> = () => {
                 isModalOpen={isUnpublishedQuizModalOpen}
                 onConfirm={() => {
                   handleTogglePublished(quiz.id, true);
+                  handleCopyUrlAndNotify(quiz.hash, t('success_messages.quiz_link_copied'));
                 }}
                 onCancel={() => {
                   handleCopyUrlAndNotify(quiz.hash, t('success_messages.quiz_link_copied'));


### PR DESCRIPTION
### Description
"Copy link" action should copy URL and show success after "unpublished" modal.

### Task
https://app.asana.com/1/1155076882573518/task/1212787865769442/comment/1212980616512942