### PR TITLE
chore: dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,8 @@ updates:
         patterns:
           - "*"
     ignore:
-      - dependency-name: "react"
+      - dependency-name: "*react*"
+      - update-types: "version-update:semver-major"
 
   # API
   - package-ecosystem: "npm"
@@ -39,7 +40,8 @@ updates:
         patterns:
           - "*"
     ignore:
-      - dependency-name: "react"
+      - dependency-name: "*react*"
+      - update-types: "version-update:semver-major"
 
   - package-ecosystem: "npm"
     directory: "/apps/spaces"
@@ -52,7 +54,8 @@ updates:
         patterns:
           - "*"
     ignore:
-      - dependency-name: "react"
+      - dependency-name: "*react*"
+      - update-types: "version-update:semver-major"
 
   # Shared packages
   - package-ecosystem: "npm"
@@ -66,7 +69,8 @@ updates:
         patterns:
           - "*"
     ignore:
-      - dependency-name: "react"
+      - dependency-name: "*react*"
+      - update-types: "version-update:semver-major"
 
   - package-ecosystem: "npm"
     directory: "/packages/tooling-config"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,8 @@ updates:
           - "*"
     ignore:
       - dependency-name: "*react*"
-      - update-types: 
-        - "version-update:semver-major"
+        update-types: 
+          - "version-update:semver-major"
 
   # API
   - package-ecosystem: "npm"
@@ -42,8 +42,8 @@ updates:
           - "*"
     ignore:
       - dependency-name: "*react*"
-      - update-types:
-        - "version-update:semver-major"
+        update-types: 
+          - "version-update:semver-major"
 
   - package-ecosystem: "npm"
     directory: "/apps/spaces"
@@ -57,8 +57,8 @@ updates:
           - "*"
     ignore:
       - dependency-name: "*react*"
-      - update-types: 
-        - "version-update:semver-major"
+        update-types: 
+          - "version-update:semver-major"
 
   # Shared packages
   - package-ecosystem: "npm"
@@ -73,8 +73,8 @@ updates:
           - "*"
     ignore:
       - dependency-name: "*react*"
-      - update-types: 
-        - "version-update:semver-major"
+        update-types: 
+          - "version-update:semver-major"
 
   - package-ecosystem: "npm"
     directory: "/packages/tooling-config"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
       - dependency-name: "*react*"
         update-types: 
           - "version-update:semver-major"
+    versioning-strategy: increase
 
   # API
   - package-ecosystem: "npm"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,8 @@ updates:
           - "*"
     ignore:
       - dependency-name: "*react*"
-      - update-types: "version-update:semver-major"
+      - update-types: 
+        - "version-update:semver-major"
 
   # API
   - package-ecosystem: "npm"
@@ -41,7 +42,8 @@ updates:
           - "*"
     ignore:
       - dependency-name: "*react*"
-      - update-types: "version-update:semver-major"
+      - update-types:
+        - "version-update:semver-major"
 
   - package-ecosystem: "npm"
     directory: "/apps/spaces"
@@ -55,7 +57,8 @@ updates:
           - "*"
     ignore:
       - dependency-name: "*react*"
-      - update-types: "version-update:semver-major"
+      - update-types: 
+        - "version-update:semver-major"
 
   # Shared packages
   - package-ecosystem: "npm"
@@ -70,7 +73,8 @@ updates:
           - "*"
     ignore:
       - dependency-name: "*react*"
-      - update-types: "version-update:semver-major"
+      - update-types: 
+        - "version-update:semver-major"
 
   - package-ecosystem: "npm"
     directory: "/packages/tooling-config"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,19 +5,21 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "semiannually"
     target-branch: "development"
     open-pull-requests-limit: 10
     groups:
       workspace-dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "react"
 
   # API
   - package-ecosystem: "npm"
     directory: "/apps/api"
     schedule:
-      interval: "weekly"
+      interval: "semiannually"
     target-branch: "development"
     open-pull-requests-limit: 10
     groups:
@@ -29,41 +31,47 @@ updates:
   - package-ecosystem: "npm"
     directory: "/apps/public"
     schedule:
-      interval: "weekly"
+      interval: "semiannually"
     target-branch: "development"
     open-pull-requests-limit: 10
     groups:
       workspace-dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "react"
 
   - package-ecosystem: "npm"
     directory: "/apps/spaces"
     schedule:
-      interval: "weekly"
+      interval: "semiannually"
     target-branch: "development"
     open-pull-requests-limit: 10
     groups:
       workspace-dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "react"
 
   # Shared packages
   - package-ecosystem: "npm"
     directory: "/packages/shira-ui"
     schedule:
-      interval: "weekly"
+      interval: "semiannually"
     target-branch: "development"
     open-pull-requests-limit: 10
     groups:
       workspace-dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "react"
 
   - package-ecosystem: "npm"
     directory: "/packages/tooling-config"
     schedule:
-      interval: "weekly"
+      interval: "semiannually"
     target-branch: "development"
     open-pull-requests-limit: 10
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,7 @@ updates:
       workspace-dependencies:
         patterns:
           - "*"
+    versioning-strategy: increase
 
   # Frontend apps
   - package-ecosystem: "npm"
@@ -45,6 +46,7 @@ updates:
       - dependency-name: "*react*"
         update-types: 
           - "version-update:semver-major"
+    versioning-strategy: increase
 
   - package-ecosystem: "npm"
     directory: "/apps/spaces"
@@ -60,6 +62,7 @@ updates:
       - dependency-name: "*react*"
         update-types: 
           - "version-update:semver-major"
+    versioning-strategy: increase
 
   # Shared packages
   - package-ecosystem: "npm"
@@ -76,6 +79,7 @@ updates:
       - dependency-name: "*react*"
         update-types: 
           - "version-update:semver-major"
+    versioning-strategy: increase
 
   - package-ecosystem: "npm"
     directory: "/packages/tooling-config"
@@ -87,3 +91,4 @@ updates:
       workspace-dependencies:
         patterns:
           - "*"
+    versioning-strategy: increase


### PR DESCRIPTION
### Description
- Set how often to check for new versions to semiannually (in january and july) until we fully polish dependabot configuration.
- Ignore major version updates for react.
- Set [versioning strategy](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--) to `increase`.