### PR TITLE
fix: reset file input value after file error

### DIFF
--- a/apps/api/src/modules/learner/controllers/auth.learner.controller.ts
+++ b/apps/api/src/modules/learner/controllers/auth.learner.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Delete, Get, Inject, Post, UploadedFile, UseInterceptors } from '@nestjs/common';
+import { Body, Delete, Get, Inject, Post, UploadedFile, UseFilters, UseInterceptors } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { TYPES } from '../interfaces';
 import { InviteLearnerDto } from '../dto/invitation.learner.dto';
@@ -21,6 +21,9 @@ import { ApiLogger } from 'src/utils/logger/api-logger.service';
 import { QuizUnassignmentFailedException } from '../exceptions/unassign-quiz.learner.exception';
 import { BulkCsvProcessingException } from '../exceptions/csv-bulk-could-not-process.learner.exception';
 import { BulkInviteValidatedRequestDto } from '../dto/learner-bulk-invite-request.dto';
+import { MulterBulkCsvExceptionFilter } from '../filters/multer-bulk-csv-exception.filter';
+
+const MAX_CSV_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 
 @AuthController('learners')
 export class AuthLearnerController {
@@ -68,7 +71,8 @@ export class AuthLearnerController {
 
   @Post('invitations/bulk/verify')
   @Roles(Role.SpaceAdmin)
-  @UseInterceptors(FileInterceptor('file'))
+  @UseInterceptors(FileInterceptor('file', { limits: { fileSize: MAX_CSV_FILE_SIZE_BYTES } }))
+  @UseFilters(MulterBulkCsvExceptionFilter)
   async verifyBulkInvite(
     @UploadedFile() file: Express.Multer.File,
     @SpaceId() spaceId: number

--- a/apps/api/src/modules/learner/exceptions/csv-bulk-file-too-large.learner.exception.ts
+++ b/apps/api/src/modules/learner/exceptions/csv-bulk-file-too-large.learner.exception.ts
@@ -1,0 +1,11 @@
+import { HttpException, HttpStatus } from "@nestjs/common";
+import { LearnerBulkUploadErrorCode } from "./errors/learner-bulk.error-codes";
+
+export class BulkCsvFileTooLargeException extends HttpException {
+  constructor(message?: string) {
+    const cause = "CSV file too large for bulk learner upload";
+    super(LearnerBulkUploadErrorCode.FileTooLarge, HttpStatus.PAYLOAD_TOO_LARGE, {
+      cause: message ?? cause,
+    });
+  }
+}

--- a/apps/api/src/modules/learner/exceptions/errors/learner-bulk.error-codes.ts
+++ b/apps/api/src/modules/learner/exceptions/errors/learner-bulk.error-codes.ts
@@ -3,4 +3,5 @@ export enum LearnerBulkUploadErrorCode {
   InvalidFormatting = "invalid_formatting",
   InvalidFileFormat = "invalid_file_format",
   CSVParsingError = "csv_parsing_error",
+  FileTooLarge = "file_too_large",
 }

--- a/apps/api/src/modules/learner/exceptions/index.ts
+++ b/apps/api/src/modules/learner/exceptions/index.ts
@@ -15,4 +15,5 @@ export { AlreadyCompletedException } from './already-completed.learner-quiz.exce
 export { CSVParsingException } from './csv-bulk-parse.learner.exception';
 export { TooManyRowsException } from './csv-bulk-too-many-rows.learner.exception';
 export { InvalidFileFormatException } from './csv-bulk-invalid-format.learner.exception';
+export { BulkCsvFileTooLargeException } from './csv-bulk-file-too-large.learner.exception';
 export { BulkCsvProcessingException as CouldNotProcessCsvException } from './csv-bulk-could-not-process.learner.exception';

--- a/apps/api/src/modules/learner/filters/multer-bulk-csv-exception.filter.ts
+++ b/apps/api/src/modules/learner/filters/multer-bulk-csv-exception.filter.ts
@@ -1,0 +1,27 @@
+import { ArgumentsHost, Catch, ExceptionFilter } from "@nestjs/common";
+import { MulterError } from "multer";
+import { BulkCsvFileTooLargeException } from "../exceptions";
+import { BulkCsvProcessingException } from "../exceptions/csv-bulk-could-not-process.learner.exception";
+
+@Catch(MulterError)
+export class MulterBulkCsvExceptionFilter implements ExceptionFilter {
+  catch(exception: MulterError, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse();
+
+    const mapped =
+      exception.code === "LIMIT_FILE_SIZE"
+        ? new BulkCsvFileTooLargeException()
+        : new BulkCsvProcessingException();
+
+    const status = mapped.getStatus();
+    const body = mapped.getResponse();
+
+    if (typeof body === "string") {
+      response.status(status).json({ statusCode: status, message: body });
+      return;
+    }
+
+    response.status(status).json(body);
+  }
+}

--- a/apps/spaces/src/components/LearnerBulkImportLayout/components/UploadCsvStep/index.tsx
+++ b/apps/spaces/src/components/LearnerBulkImportLayout/components/UploadCsvStep/index.tsx
@@ -117,8 +117,7 @@ export const UploadCsvStep: FunctionComponent<Props> = ({
               accept=".csv"
               hidden
               onChange={(event) => {
-                const file = event.target.files?.[0] ?? null;
-                onFileChange(file);
+                onFileChange(event.target.files?.[0] ?? null);
                 event.target.value = "";
               }}
             />

--- a/apps/spaces/src/components/LearnerBulkImportLayout/components/UploadCsvStep/index.tsx
+++ b/apps/spaces/src/components/LearnerBulkImportLayout/components/UploadCsvStep/index.tsx
@@ -199,7 +199,7 @@ export const UploadCsvStep: FunctionComponent<Props> = ({
           <CenteredHeaderRow>
             <GoAlertFill size={20} color={defaultTheme.colors.error7} />
             <SubHeading1>
-              {t(`error_messages.learners_bulk_import.${uploadError}.title`, {
+              {t(`${uploadError}.title`, {
                 defaultValue: t(`error_messages.something_went_wrong`),
               })}
             </SubHeading1>
@@ -235,7 +235,7 @@ export const UploadCsvStep: FunctionComponent<Props> = ({
 
             <CenteredText>
               <Body1>
-                {t(`error_messages.learners_bulk_import.${uploadError}.subtitle`, {
+                {t(`${uploadError}.subtitle`, {
                   defaultValue: t(`error_messages.something_went_wrong`),
                 })}
               </Body1>

--- a/apps/spaces/src/components/LearnerBulkImportLayout/components/UploadCsvStep/index.tsx
+++ b/apps/spaces/src/components/LearnerBulkImportLayout/components/UploadCsvStep/index.tsx
@@ -116,7 +116,11 @@ export const UploadCsvStep: FunctionComponent<Props> = ({
               type="file"
               accept=".csv"
               hidden
-              onChange={(event) => onFileChange(event.target.files?.[0] ?? null)}
+              onChange={(event) => {
+                const file = event.target.files?.[0] ?? null;
+                onFileChange(file);
+                event.target.value = "";
+              }}
             />
 
             <DropzoneContent>

--- a/apps/spaces/src/components/LearnerBulkImportLayout/components/UploadCsvStep/index.tsx
+++ b/apps/spaces/src/components/LearnerBulkImportLayout/components/UploadCsvStep/index.tsx
@@ -199,7 +199,7 @@ export const UploadCsvStep: FunctionComponent<Props> = ({
           <CenteredHeaderRow>
             <GoAlertFill size={20} color={defaultTheme.colors.error7} />
             <SubHeading1>
-              {t(`${uploadError}.title`, {
+              {t(`error_messages.learners_bulk_import.${uploadError}.title`, {
                 defaultValue: t(`error_messages.something_went_wrong`),
               })}
             </SubHeading1>
@@ -235,7 +235,7 @@ export const UploadCsvStep: FunctionComponent<Props> = ({
 
             <CenteredText>
               <Body1>
-                {t(`${uploadError}.subtitle`, {
+                {t(`error_messages.learners_bulk_import.${uploadError}.subtitle`, {
                   defaultValue: t(`error_messages.something_went_wrong`),
                 })}
               </Body1>

--- a/apps/spaces/src/components/LearnerBulkImportLayout/index.tsx
+++ b/apps/spaces/src/components/LearnerBulkImportLayout/index.tsx
@@ -17,6 +17,8 @@ export const LearnerBulkImportLayout: FunctionComponent<Props> = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
+  const MAX_CSV_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+
   const [step, handleStep] = useState(0);
 
   const [isExitBulkImportModalOpen, setIsExitBulkImportModalOpen] = useState(false);
@@ -72,6 +74,11 @@ export const LearnerBulkImportLayout: FunctionComponent<Props> = () => {
 
     lastVerifiedFileKey.current = null;
     lastInvitedFileKey.current = null;
+
+    if (file.size > MAX_CSV_FILE_SIZE_BYTES) {
+      setUploadError("error_messages.learners_bulk_import.file_too_large");
+      return;
+    }
   };
 
   const clearSelectedFile = () => {

--- a/apps/spaces/src/components/LearnerBulkImportLayout/index.tsx
+++ b/apps/spaces/src/components/LearnerBulkImportLayout/index.tsx
@@ -76,7 +76,7 @@ export const LearnerBulkImportLayout: FunctionComponent<Props> = () => {
     lastInvitedFileKey.current = null;
 
     if (file.size > MAX_CSV_FILE_SIZE_BYTES) {
-      setUploadError("error_messages.learners_bulk_import.file_too_large");
+      setUploadError("file_too_large");
       return;
     }
   };

--- a/apps/spaces/src/language/locales/en.json
+++ b/apps/spaces/src/language/locales/en.json
@@ -564,6 +564,10 @@
             "invalid_formatting": {
                 "title": "Error: Invalid formatting",
                 "subtitle": "Please make sure your spreadsheet is formatted according to the guidelines above and try again."
+            },
+            "file_too_large": {
+                "title": "Error: File is too large",
+                "subtitle": "Please upload a CSV that is 10 MB or smaller and try again."
             }
         }
     },


### PR DESCRIPTION
### Description
- Fix an issue where the file input kept the previously selected file after a file validation/upload error.
- Add specific validation for max file size (10mb).

### Task
https://app.asana.com/1/1155076882573518/project/1211894767921465/task/1213423479831281