### PR TITLE
refactor: delete quiz/question modal msg

### DIFF
--- a/apps/api/src/modules/quiz/dto/read-plain.quiz.dto.ts
+++ b/apps/api/src/modules/quiz/dto/read-plain.quiz.dto.ts
@@ -36,4 +36,9 @@ export class ReadPlainQuizDto {
   @Transform(({ value }) => Number(value))
   @IsNumber()
   questionsCount: number;
+
+  @Expose()
+  @Transform(({ value }) => Boolean(Number(value)))
+  @IsBoolean()
+  hasResults: boolean;
 }

--- a/apps/api/src/modules/quiz/services/list.quiz.service.ts
+++ b/apps/api/src/modules/quiz/services/list.quiz.service.ts
@@ -15,7 +15,7 @@ export class ListQuizService implements IListQuizService {
     private readonly quizRepo: Repository<QuizEntity>,
   ) { }
 
-  async execute(spaceId: number) {
+  async execute(spaceId: number): Promise<ReadPlainQuizDto[]> {
 
     const quizzes = await this.quizRepo
       .createQueryBuilder('quiz')
@@ -39,7 +39,11 @@ export class ListQuizService implements IListQuizService {
         'quiz.hash AS hash',
         'quiz.published AS published',
         'quiz.visibility AS visibility',
-        `(SELECT COUNT(*) FROM quizzes_questions qq_count WHERE qq_count.quiz_id = quiz.id) AS questionsCount`
+        `(SELECT COUNT(*) FROM quizzes_questions qq_count WHERE qq_count.quiz_id = quiz.id) AS questionsCount`,
+        `EXISTS(
+          SELECT 1 FROM quiz_runs qr
+          WHERE qr.quiz_id = quiz.id AND qr.finished_at IS NOT NULL
+        ) AS hasResults`,
       ])
       .addSelect(`GREATEST
         (

--- a/apps/public/package.json
+++ b/apps/public/package.json
@@ -18,7 +18,7 @@
     "@types/react": "^18.0.18",
     "@types/react-dom": "^18.0.6",
     "assert": "^2.1.0",
-    "axios": "^1.15.0",
+    "axios": "^1.16.0",
     "babel-jest": "^27.4.2",
     "babel-loader": "^8.2.3",
     "babel-plugin-named-asset-import": "^0.3.8",

--- a/apps/spaces/package.json
+++ b/apps/spaces/package.json
@@ -41,7 +41,7 @@
     "@types/react": "^18.0.20",
     "@types/react-dom": "^18.0.6",
     "autosize": "^5.0.1",
-    "axios": "^1.15.0",
+    "axios": "^1.16.0",
     "concat-stream": "^2.0.0",
     "date-fns": "^4.1.0",
     "i18next": "^22.5.1",

--- a/apps/spaces/src/components/DashboardLayout/index.tsx
+++ b/apps/spaces/src/components/DashboardLayout/index.tsx
@@ -25,7 +25,7 @@ import { QuizLimitModal } from "../modals/QuizLimitModal";
 import { ViewPlansModal } from "../modals/ViewPlansModal";
 import { FirstLoginModal } from "../modals/FirstLoginModal";
 import { MobileResponsivenessBanner } from "../MobileResponsivenessBanner";
-import { getQuizResults, QuizResultsResponse } from "../../fetch/results";
+import { quizHasResults } from "../../fetch/results";
 
 interface Props { }
 
@@ -75,7 +75,7 @@ export const DashboardLayout: FunctionComponent<Props> = () => {
   const [unpublishedQuizId, setUnpublishedQuizId] = useState<number | null>(null);
 
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const [resultsData, setResultsData] = useState<QuizResultsResponse | null>(null);
+  const [selectedQuizHasResults, setSelectedQuizHasResults] = useState(false);
   const [isUnpublishedQuizCopyLinkModalOpen, setIsUnpublishedQuizCopyLinkModalOpen] = useState(false);
   const [isUnpublishQuizModalOpen, setIsUnpublishQuizModalOpen] = useState(false);
   const [isCheckoutSuccessModalOpen, setIsCheckoutSuccessModalOpen] = useState(
@@ -120,16 +120,15 @@ export const DashboardLayout: FunctionComponent<Props> = () => {
   useEffect(() => {
     const fetchResults = async () => {
       if (!selectedCard?.id || !isDeleteModalOpen) {
-        setResultsData(null);
+        setSelectedQuizHasResults(false);
         return;
       }
 
       try {
-        const data = await getQuizResults(selectedCard.id);
-        setResultsData(data);
+        const hasResults = await quizHasResults(selectedCard.id);
+        setSelectedQuizHasResults(hasResults);
       } catch (error) {
-        console.error('Failed to fetch quiz results:', error);
-        setResultsData(null);
+        setSelectedQuizHasResults(false);
       }
     };
 
@@ -251,7 +250,7 @@ export const DashboardLayout: FunctionComponent<Props> = () => {
       return t('quizzes.last_modified', { date: time });
     }, [filteredCards, i18n.language]);
 
-  const hasResults = !!resultsData?.metrics?.completedCount;
+  const hasResults = selectedQuizHasResults;
 
   return (
     <Container id="dashboard-layout">
@@ -372,12 +371,12 @@ export const DashboardLayout: FunctionComponent<Props> = () => {
             onDelete={() => {
               deleteQuiz(selectedCard?.id)
               handleSelectedCard(null);
-              setResultsData(null);
+              setSelectedQuizHasResults(false);
             }}
             onCancel={() => {
               setIsDeleteModalOpen(false);
               handleSelectedCard(null);
-              setResultsData(null);
+              setSelectedQuizHasResults(false);
             }}
             isModalOpen={isDeleteModalOpen}
           />

--- a/apps/spaces/src/components/DashboardLayout/index.tsx
+++ b/apps/spaces/src/components/DashboardLayout/index.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent, useCallback, useEffect, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
-import { Sidebar, styled, H2, SubHeading3, Body1, FilterButton, useAdminSidebar, Card, Banner } from "@shira/ui";
+import { Sidebar, styled, H2, SubHeading3, Body1, FilterButton, useAdminSidebar, Card } from "@shira/ui";
 import { shallow } from "zustand/shallow";
 import { useStore } from "../../store";
 import { formatDistance } from "date-fns";
@@ -25,6 +25,7 @@ import { QuizLimitModal } from "../modals/QuizLimitModal";
 import { ViewPlansModal } from "../modals/ViewPlansModal";
 import { FirstLoginModal } from "../modals/FirstLoginModal";
 import { MobileResponsivenessBanner } from "../MobileResponsivenessBanner";
+import { getQuizResults, QuizResultsResponse } from "../../fetch/results";
 
 interface Props { }
 
@@ -74,6 +75,7 @@ export const DashboardLayout: FunctionComponent<Props> = () => {
   const [unpublishedQuizId, setUnpublishedQuizId] = useState<number | null>(null);
 
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [resultsData, setResultsData] = useState<QuizResultsResponse | null>(null);
   const [isUnpublishedQuizCopyLinkModalOpen, setIsUnpublishedQuizCopyLinkModalOpen] = useState(false);
   const [isUnpublishQuizModalOpen, setIsUnpublishQuizModalOpen] = useState(false);
   const [isCheckoutSuccessModalOpen, setIsCheckoutSuccessModalOpen] = useState(
@@ -114,6 +116,25 @@ export const DashboardLayout: FunctionComponent<Props> = () => {
   useEffect(() => {
     setCards(quizzes)
   }, [quizzes]);
+
+  useEffect(() => {
+    const fetchSelectedQuizResults = async () => {
+      if (!selectedCard?.id || !isDeleteModalOpen) {
+        setResultsData(null);
+        return;
+      }
+
+      try {
+        const data = await getQuizResults(selectedCard.id);
+        setResultsData(data);
+      } catch (error) {
+        console.error('Failed to fetch quiz results:', error);
+        setResultsData(null);
+      }
+    };
+
+    fetchSelectedQuizResults();
+  }, [isDeleteModalOpen, selectedCard]);
 
   useEffect(() => {
     if (t(SUCCESS_MESSAGES[quizActionSuccess])) {
@@ -230,6 +251,8 @@ export const DashboardLayout: FunctionComponent<Props> = () => {
       return t('quizzes.last_modified', { date: time });
     }, [filteredCards, i18n.language]);
 
+  const hasResults = !!resultsData?.metrics?.completedCount;
+
   return (
     <Container id="dashboard-layout">
       <Sidebar
@@ -332,21 +355,29 @@ export const DashboardLayout: FunctionComponent<Props> = () => {
             content={(
               <div>
                 {t('modals.delete_quiz.subtitle')}
-                <br /><br />
-                <QuizWarningNote>
-                  {t('modals.delete_quiz.note')}
-                </QuizWarningNote>
-                {t('modals.delete_quiz.message')}
+                {hasResults && (
+                  <>
+                    <br /><br />
+                    <QuizWarningLine>
+                      <QuizWarningNote>
+                        {t('modals.delete_quiz.note')}
+                      </QuizWarningNote>
+                      {t('modals.delete_quiz.message')}
+                    </QuizWarningLine>
+                  </>
+                )}
               </div>
             )}
             setIsModalOpen={setIsDeleteModalOpen}
             onDelete={() => {
               deleteQuiz(selectedCard?.id)
               handleSelectedCard(null);
+              setResultsData(null);
             }}
             onCancel={() => {
               setIsDeleteModalOpen(false);
               handleSelectedCard(null);
+              setResultsData(null);
             }}
             isModalOpen={isDeleteModalOpen}
           />
@@ -512,8 +543,11 @@ const CardGrid = styled.div`
   }
 `;
 
-
 const QuizWarningNote = styled.span`
   color: #d73527;
   font-weight: 500;
+`;
+
+const QuizWarningLine = styled.span`
+  display: inline;
 `;

--- a/apps/spaces/src/components/DashboardLayout/index.tsx
+++ b/apps/spaces/src/components/DashboardLayout/index.tsx
@@ -118,7 +118,7 @@ export const DashboardLayout: FunctionComponent<Props> = () => {
   }, [quizzes]);
 
   useEffect(() => {
-    const fetchSelectedQuizResults = async () => {
+    const fetchResults = async () => {
       if (!selectedCard?.id || !isDeleteModalOpen) {
         setResultsData(null);
         return;
@@ -133,8 +133,8 @@ export const DashboardLayout: FunctionComponent<Props> = () => {
       }
     };
 
-    fetchSelectedQuizResults();
-  }, [isDeleteModalOpen, selectedCard]);
+    fetchResults();
+  }, [selectedCard]);
 
   useEffect(() => {
     if (t(SUCCESS_MESSAGES[quizActionSuccess])) {

--- a/apps/spaces/src/components/DashboardLayout/index.tsx
+++ b/apps/spaces/src/components/DashboardLayout/index.tsx
@@ -25,7 +25,6 @@ import { QuizLimitModal } from "../modals/QuizLimitModal";
 import { ViewPlansModal } from "../modals/ViewPlansModal";
 import { FirstLoginModal } from "../modals/FirstLoginModal";
 import { MobileResponsivenessBanner } from "../MobileResponsivenessBanner";
-import { quizHasResults } from "../../fetch/results";
 
 interface Props { }
 
@@ -75,7 +74,6 @@ export const DashboardLayout: FunctionComponent<Props> = () => {
   const [unpublishedQuizId, setUnpublishedQuizId] = useState<number | null>(null);
 
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const [selectedQuizHasResults, setSelectedQuizHasResults] = useState(false);
   const [isUnpublishedQuizCopyLinkModalOpen, setIsUnpublishedQuizCopyLinkModalOpen] = useState(false);
   const [isUnpublishQuizModalOpen, setIsUnpublishQuizModalOpen] = useState(false);
   const [isCheckoutSuccessModalOpen, setIsCheckoutSuccessModalOpen] = useState(
@@ -116,24 +114,6 @@ export const DashboardLayout: FunctionComponent<Props> = () => {
   useEffect(() => {
     setCards(quizzes)
   }, [quizzes]);
-
-  useEffect(() => {
-    const fetchResults = async () => {
-      if (!selectedCard?.id || !isDeleteModalOpen) {
-        setSelectedQuizHasResults(false);
-        return;
-      }
-
-      try {
-        const hasResults = await quizHasResults(selectedCard.id);
-        setSelectedQuizHasResults(hasResults);
-      } catch (error) {
-        setSelectedQuizHasResults(false);
-      }
-    };
-
-    fetchResults();
-  }, [selectedCard]);
 
   useEffect(() => {
     if (t(SUCCESS_MESSAGES[quizActionSuccess])) {
@@ -250,8 +230,6 @@ export const DashboardLayout: FunctionComponent<Props> = () => {
       return t('quizzes.last_modified', { date: time });
     }, [filteredCards, i18n.language]);
 
-  const hasResults = selectedQuizHasResults;
-
   return (
     <Container id="dashboard-layout">
       <Sidebar
@@ -354,7 +332,7 @@ export const DashboardLayout: FunctionComponent<Props> = () => {
             content={(
               <div>
                 {t('modals.delete_quiz.subtitle')}
-                {hasResults && (
+                {selectedCard?.hasResults && (
                   <>
                     <br /><br />
                     <QuizWarningLine>
@@ -371,12 +349,10 @@ export const DashboardLayout: FunctionComponent<Props> = () => {
             onDelete={() => {
               deleteQuiz(selectedCard?.id)
               handleSelectedCard(null);
-              setSelectedQuizHasResults(false);
             }}
             onCancel={() => {
               setIsDeleteModalOpen(false);
               handleSelectedCard(null);
-              setSelectedQuizHasResults(false);
             }}
             isModalOpen={isDeleteModalOpen}
           />

--- a/apps/spaces/src/components/QuizViewLayout/components/QuestionList.tsx
+++ b/apps/spaces/src/components/QuizViewLayout/components/QuestionList.tsx
@@ -272,8 +272,16 @@ export const QuestionsList: FunctionComponent<QuestionsListProps> = ({
             <div>
               {t('modals.delete_question.message')}
               <br /><br />
-              <WarningNote>{t('modals.delete_question.note')}</WarningNote>
-              {t('modals.delete_question.warning')}
+              {hasResults && (
+                <>
+                  <WarningLine>
+                    <WarningNote>
+                      {t('modals.delete_question.note')}
+                    </WarningNote>
+                    {t('modals.delete_question.warning')}
+                  </WarningLine>
+                </>
+              )}
             </div>
           }
           setIsModalOpen={() => {
@@ -388,6 +396,10 @@ const ActionButton = styled.button`
 const WarningNote = styled.span`
   color: #d73527;
   font-weight: 500;
+`;
+
+const WarningLine = styled.span`
+  display: inline;
 `;
 
 const SpinningLoader = styled(FiLoader)`

--- a/apps/spaces/src/components/QuizViewLayout/index.tsx
+++ b/apps/spaces/src/components/QuizViewLayout/index.tsx
@@ -68,7 +68,7 @@ export const QuizViewLayout: FunctionComponent<Props> = () => {
     fetchQuizzes: state.fetchQuizzes,
     quizzes: state.quizzes,
   }), shallow)
-    console.log("🚀 ~ QuizViewLayout ~ quizzes:", quizzes)
+  console.log("🚀 ~ QuizViewLayout ~ quizzes:", quizzes)
 
   const { isCollapsed, handleCollapse, menuItems } = useAdminSidebar(navigate)
   const [isPublished, setIsPublished] = useState(false);
@@ -149,7 +149,7 @@ export const QuizViewLayout: FunctionComponent<Props> = () => {
 
     getQuiz()
     fetchQuizzes()
-    
+
     return () => {
       cleanQuizActionSuccess()
     }
@@ -275,25 +275,25 @@ export const QuizViewLayout: FunctionComponent<Props> = () => {
                     />
 
                     <GeneralTooltip
-                        enabled={!isSubActive && hasReachedLimit}
-                        show={showDuplicateTooltip}
-                        setShow={setShowDuplicateTooltip}
-                        label={t('dashboard.create_limit_reached')}
-                      >
-                        <Button
-                          id="duplicate-quiz-button"
-                          leftIcon={<FiCopy size={16} />}
-                          text={t('quiz.actions.duplicate')}
-                          type="outline"
-                          disabled={!isSubActive && hasReachedLimit}
-                          onClick={() => {
-                            if (quiz) {
-                              startDuplicateQuizFlow(quiz);
-                            }
-                          }}
-                        />
+                      enabled={!isSubActive && hasReachedLimit}
+                      show={showDuplicateTooltip}
+                      setShow={setShowDuplicateTooltip}
+                      label={t('dashboard.create_limit_reached')}
+                    >
+                      <Button
+                        id="duplicate-quiz-button"
+                        leftIcon={<FiCopy size={16} />}
+                        text={t('quiz.actions.duplicate')}
+                        type="outline"
+                        disabled={!isSubActive && hasReachedLimit}
+                        onClick={() => {
+                          if (quiz) {
+                            startDuplicateQuizFlow(quiz);
+                          }
+                        }}
+                      />
                     </GeneralTooltip>
-                    
+
                     {quiz.visibility !== 'private' && (
                       <PublishToggleWrapper
                         $showHelpCursor={disableCopyLinkButton}
@@ -384,11 +384,17 @@ export const QuizViewLayout: FunctionComponent<Props> = () => {
                 content={
                   <div>
                     {t('modals.delete_quiz.subtitle')}
-                    <br /><br />
-                    <QuizWarningNote>
-                      {t('modals.delete_quiz.note')}
-                    </QuizWarningNote>
-                    {t('modals.delete_quiz.message')}
+                    {hasResults && (
+                      <>
+                        <br /><br />
+                        <QuizWarningLine>
+                          <QuizWarningNote>
+                            {t('modals.delete_quiz.note')}
+                          </QuizWarningNote>
+                          {t('modals.delete_quiz.message')}
+                        </QuizWarningLine>
+                      </>
+                    )}
                   </div>
                 }
                 setIsModalOpen={setIsDeleteModalOpen}
@@ -531,6 +537,10 @@ const LeftButtons = styled.div`
 const QuizWarningNote = styled.span`
   color: #d73527;
   font-weight: 500;
+`;
+
+const QuizWarningLine = styled.span`
+  display: inline;
 `;
 
 const PublishToggleWrapper = styled.div<{ $showHelpCursor: boolean }>`

--- a/apps/spaces/src/fetch/results.ts
+++ b/apps/spaces/src/fetch/results.ts
@@ -47,8 +47,3 @@ const getQuizResultsFromAPI = async (quizId: number): Promise<QuizResultsRespons
 export const getQuizResults = async (quizId: number): Promise<QuizResultsResponse> => {
   return getQuizResultsFromAPI(quizId);
 };
-
-export const quizHasResults = async (quizId: number): Promise<boolean> => {
-  const results = await getQuizResults(quizId);
-  return results.metrics.completedCount > 0;
-}

--- a/apps/spaces/src/fetch/results.ts
+++ b/apps/spaces/src/fetch/results.ts
@@ -6,7 +6,7 @@ export interface QuizResultsResponse {
     title: string;
     totalQuestions: number;
   };
-  
+
   metrics: {
     completedCount: number;
     averageScore: number;
@@ -44,6 +44,11 @@ const getQuizResultsFromAPI = async (quizId: number): Promise<QuizResultsRespons
   }
 };
 
-export const getQuizResults = async (quizId: number): Promise<QuizResultsResponse> => {  
+export const getQuizResults = async (quizId: number): Promise<QuizResultsResponse> => {
   return getQuizResultsFromAPI(quizId);
 };
+
+export const quizHasResults = async (quizId: number): Promise<boolean> => {
+  const results = await getQuizResults(quizId);
+  return results.metrics.completedCount > 0;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1663,7 +1663,7 @@
         "@types/react": "^18.0.18",
         "@types/react-dom": "^18.0.6",
         "assert": "^2.1.0",
-        "axios": "^1.15.0",
+        "axios": "^1.16.0",
         "babel-jest": "^27.4.2",
         "babel-loader": "^8.2.3",
         "babel-plugin-named-asset-import": "^0.3.8",
@@ -1939,6 +1939,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "apps/public/node_modules/axios": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "apps/public/node_modules/babel-jest": {
@@ -2295,7 +2305,7 @@
         "@types/react": "^18.0.20",
         "@types/react-dom": "^18.0.6",
         "autosize": "^5.0.1",
-        "axios": "^1.15.0",
+        "axios": "^1.16.0",
         "concat-stream": "^2.0.0",
         "date-fns": "^4.1.0",
         "i18next": "^22.5.1",
@@ -2505,6 +2515,16 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "apps/spaces/node_modules/axios": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "apps/spaces/node_modules/eslint": {
@@ -13114,17 +13134,6 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4085,8 +4085,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "license": "MIT",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.28.6",
         "@babel/helper-plugin-utils": "^7.28.6",


### PR DESCRIPTION
### Description
- In `QuizViewLayout`, `hasResults` was already mapped since full results are used.
- In `DashboardLayout`, now `hasResults` is extracted from get quizzes endpoint. Example response with new field:

```
[
    {
        "id": 186,
        "title": "Quiz",
        "hash": "c5473e7cdeab01c74e7f43cd493379889993083f",
        "published": 1,
        "updatedAt": "2026-05-11T19:26:35.000Z",
        "latestGlobalUpdate": "2026-05-11 19:26:35",
        "visibility": "public",
        "questionsCount": 4,
        "hasResults": true
    },
    {
        "id": 190,
        "title": "Quiz name",
        "hash": "61a4e9f0f2f3d14770fbc65d4f3c211009027005",
        "published": 1,
        "updatedAt": "2026-04-27T16:06:14.000Z",
        "latestGlobalUpdate": "2026-04-27 16:06:14",
        "visibility": "public",
        "questionsCount": 1,
        "hasResults": false
    }
]
```



### Task
https://app.asana.com/1/1155076882573518/project/1201968080212131/task/1212787865718078