### PR TITLE
CVE 012

### DIFF
--- a/apps/api/src/modules/auth/controllers/login.auth.controller.ts
+++ b/apps/api/src/modules/auth/controllers/login.auth.controller.ts
@@ -26,17 +26,24 @@ export class LoginAuthController {
     const user = await this.validateAuthService.execute({ email, password });
     const authToken = await this.generateTokenAuthService.execute(user);
 
-    response
-      .cookie('access_token', authToken.access_token, {
-        httpOnly: true,
-        expires: new Date(Date.now() + 1000 * 60 * 60),
-        domain: process.env.COOKIE_DOMAIN,
-        secure: true
-      })
-      .send({
-        ...authToken,
-        user,
-      });
+    const cookieOptions = {
+      httpOnly: true,
+      expires: new Date(Date.now() + 1000 * 60 * 60),
+      domain: process.env.COOKIE_DOMAIN,
+      secure: true,
+    };
+
+    const res = response
+      .cookie('access_token', authToken.access_token, cookieOptions)
+
+    if (user.spaces?.[0]?.id) {
+      res.cookie('active_space', String(user.spaces[0].id), cookieOptions);
+    }
+
+    res.send({
+      ...authToken,
+      user,
+    });
 
       await this.markUserLoginService.execute(user.id);
   }

--- a/apps/api/src/modules/auth/controllers/login.auth.controller.ts
+++ b/apps/api/src/modules/auth/controllers/login.auth.controller.ts
@@ -30,7 +30,7 @@ export class LoginAuthController {
       httpOnly: true,
       expires: new Date(Date.now() + 1000 * 60 * 60),
       domain: process.env.COOKIE_DOMAIN,
-      secure: true,
+      secure: process.env.NODE_ENV === 'production',
     };
 
     const res = response

--- a/apps/api/src/modules/auth/controllers/logout.auth.controller.ts
+++ b/apps/api/src/modules/auth/controllers/logout.auth.controller.ts
@@ -6,12 +6,15 @@ export class LogoutAuthController {
   @Post()
   logout(@Res() response: Response) {
     console.log('[AUTH] logout - clearing httpOnly cookie');
+    const clearOptions = {
+      expires: new Date(0),
+      httpOnly: true,
+      domain: process.env.COOKIE_DOMAIN,
+    };
+
     response
-      .cookie('access_token', '', {
-        expires: new Date(0),
-        httpOnly: true,
-        domain: process.env.COOKIE_DOMAIN,
-      })
+      .cookie('access_token', '', clearOptions)
+      .cookie('active_space', '', clearOptions)
       .send();
   }
 }

--- a/apps/api/src/modules/auth/guards/roles.guard.ts
+++ b/apps/api/src/modules/auth/guards/roles.guard.ts
@@ -31,16 +31,16 @@ export class RolesGuard implements CanActivate {
       return false
     }
     
-    const spaceIdHeader = request.headers['x-space']
+    const spaceIdSource = request.cookies?.['active_space'] ?? request.headers['x-space']
     const orgIdHeader = request.headers['x-organization']
 
     let spaceId: number | null = null
     let orgId: number | null = null
 
-    if (spaceIdHeader) {
-      spaceId = parseInt(spaceIdHeader)
+    if (spaceIdSource) {
+      spaceId = parseInt(spaceIdSource)
       if (isNaN(spaceId)) {
-        throw new BadRequestException('Invalid X-Space header format')
+        throw new BadRequestException('Invalid space format')
       }
     }
 

--- a/apps/spaces/.env.development
+++ b/apps/spaces/.env.development
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=/api

--- a/apps/spaces/.env.example
+++ b/apps/spaces/.env.example
@@ -1,3 +1,3 @@
-REACT_APP_API_URL=
+REACT_APP_API_URL=   # dev: /api (uses setupProxy.js) | production: https://your-api-domain.com
 REACT_APP_PUBLIC_URL=
 REACT_APP_FLAG_LEARNER_BULK_INVITE=true

--- a/apps/spaces/src/fetch/auth.ts
+++ b/apps/spaces/src/fetch/auth.ts
@@ -1,24 +1,10 @@
 import axios from "axios"
 
-const isProduction = () => {
-  return process.env.NODE_ENV === 'production';
-}
+axios.defaults.withCredentials = true;
 
-export const fetchUser = async (spaceId?: string) => {
+export const fetchUser = async () => {
   try {
-    if (isProduction()) {
-      axios.defaults.withCredentials = true;
-    } else {
-      const token = window.localStorage.getItem('shira_access_token');
-      axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
-      if (spaceId) {
-        axios.defaults.headers.common['X-Space'] = spaceId;
-      }
-    }
-
-    const headers = !isProduction() && spaceId ? { 'X-Space': spaceId } : {};
-    const res = await axios.get(`${process.env.REACT_APP_API_URL}/user`, { headers })
-
+    const res = await axios.get(`${process.env.REACT_APP_API_URL}/user`)
     return res.data
   } catch (err) {
     console.log(`[AUTH] fetchUser - error:`, err);
@@ -29,27 +15,11 @@ export const fetchUser = async (spaceId?: string) => {
 export const login = async (email, pass) => {
   try {
     console.log(`[AUTH] login - attempting for email: ${email}`);
-    
     const res = await axios.post(`${process.env.REACT_APP_API_URL}/login`, {
       email: email,
       password: pass
     })
-
-    if (isProduction()) {
-      axios.defaults.withCredentials = true;
-      console.log(`[AUTH] login - success, using httpOnly cookie`);
-    } else {
-      const token = res.data.access_token;
-      axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
-      window.localStorage.setItem('shira_access_token', res.data.access_token);
-      const spaceId = res.data.user.spaces?.[0]?.id
-      if (spaceId) {
-        window.localStorage.setItem('shira_x_space', String(spaceId));
-        axios.defaults.headers.common['X-Space'] = String(spaceId);
-      }
-      console.log(`[AUTH] login - success, using Bearer token (dev mode)`);
-    }
-    
+    console.log(`[AUTH] login - success`);
     return res.data.user
   } catch (e) {
     console.log(`[AUTH] login - error:`, e);
@@ -59,13 +29,7 @@ export const login = async (email, pass) => {
 
 export const checkAuth = async () => {
   try {
-    if (isProduction()) {
-      return await fetchUser()
-    }
-
-    const spaceId = window.localStorage.getItem('shira_x_space')
-    if (!spaceId) return null
-    return await fetchUser(spaceId)
+    return await fetchUser()
   } catch (err) {
     console.log(`[AUTH] checkAuth - failed:`, err?.response?.status);
     return null;
@@ -76,10 +40,6 @@ export const logout = async () => {
   try {
     console.log(`[AUTH] logout - initiating`);
     await axios.post(`${process.env.REACT_APP_API_URL}/logout`)
-    window.localStorage.removeItem('shira_access_token')
-    if (!isProduction()) {
-      window.localStorage.removeItem('shira_x_space')
-    }
     console.log(`[AUTH] logout - success`);
   } catch (err) {
     console.log(`[AUTH] logout - error:`, err);

--- a/apps/spaces/src/fetch/auth.ts
+++ b/apps/spaces/src/fetch/auth.ts
@@ -4,23 +4,20 @@ const isProduction = () => {
   return process.env.NODE_ENV === 'production';
 }
 
-export const fetchUser = async (spaceId: string) => {
+export const fetchUser = async (spaceId?: string) => {
   try {
-
-    let headers = {
-      'X-Space': spaceId
-    }
-
     if (isProduction()) {
       axios.defaults.withCredentials = true;
     } else {
       const token = window.localStorage.getItem('shira_access_token');
       axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+      if (spaceId) {
+        axios.defaults.headers.common['X-Space'] = spaceId;
+      }
     }
 
+    const headers = !isProduction() && spaceId ? { 'X-Space': spaceId } : {};
     const res = await axios.get(`${process.env.REACT_APP_API_URL}/user`, { headers })
-
-    axios.defaults.headers.common['X-Space'] = spaceId;
 
     return res.data
   } catch (err) {
@@ -45,12 +42,13 @@ export const login = async (email, pass) => {
       const token = res.data.access_token;
       axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
       window.localStorage.setItem('shira_access_token', res.data.access_token);
+      const spaceId = res.data.user.spaces?.[0]?.id
+      if (spaceId) {
+        window.localStorage.setItem('shira_x_space', String(spaceId));
+        axios.defaults.headers.common['X-Space'] = String(spaceId);
+      }
       console.log(`[AUTH] login - success, using Bearer token (dev mode)`);
     }
-
-    const spaceId = res.data.user.spaces[0].id
-    window.localStorage.setItem('shira_x_space', spaceId)
-    axios.defaults.headers.common['X-Space'] = `${spaceId}`;
     
     return res.data.user
   } catch (e) {
@@ -60,27 +58,28 @@ export const login = async (email, pass) => {
 }
 
 export const checkAuth = async () => {
-  const spaceId = window.localStorage.getItem('shira_x_space')
-  
-  if (spaceId) {
-    try {
-      const fetchUserResponse = await fetchUser(spaceId)
-      return fetchUserResponse
-    } catch (err) {
-      console.log(`[AUTH] checkAuth - failed:`, err?.response?.status);
-      return null;
+  try {
+    if (isProduction()) {
+      return await fetchUser()
     }
+
+    const spaceId = window.localStorage.getItem('shira_x_space')
+    if (!spaceId) return null
+    return await fetchUser(spaceId)
+  } catch (err) {
+    console.log(`[AUTH] checkAuth - failed:`, err?.response?.status);
+    return null;
   }
-  
-  return null
 }
 
 export const logout = async () => {
   try {
     console.log(`[AUTH] logout - initiating`);
     await axios.post(`${process.env.REACT_APP_API_URL}/logout`)
-    window.localStorage.removeItem('shira_x_space')
-    window.localStorage.removeItem('shira_access_token')    
+    window.localStorage.removeItem('shira_access_token')
+    if (!isProduction()) {
+      window.localStorage.removeItem('shira_x_space')
+    }
     console.log(`[AUTH] logout - success`);
   } catch (err) {
     console.log(`[AUTH] logout - error:`, err);

--- a/apps/spaces/src/setupProxy.js
+++ b/apps/spaces/src/setupProxy.js
@@ -1,0 +1,12 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+module.exports = function (app) {
+  app.use(
+    '/api',
+    createProxyMiddleware({
+      target: 'http://localhost:3000',
+      changeOrigin: true,
+      pathRewrite: { '^/api': '' },
+    })
+  );
+};


### PR DESCRIPTION
Context
Audit recommendation: Two follow-ups would close the finding
fully. First, isolate the dev-mode Bearer token path behind a build-time feature flag (or
remove it altogether and require a working cookie path in development) so that
production-build artifacts cannot fall through to the localStorage branch under any runtime
condition. Second, store the space identifier in React state or in a non-localStorage store so
that no part of the authenticated session is reachable from script.

  What changed

  Active space cookie
  - On login, the API now sets an active_space httpOnly cookie alongside the existing access_token cookie. The value is sourced from the user's first
  space, which is already returned in the login response.
  - On logout, the active_space cookie is cleared.
  - RolesGuard reads the space from req.cookies['active_space'] instead of the X-Space request header.
  - Both cookies use secure: true in production and secure: false in development.

  Dev proxy
  - Added src/setupProxy.js to the spaces app, which proxies all /api/* requests through the CRA webpack dev server to localhost:3000. This makes API
  requests same-origin in development, so httpOnly cookies work without needing HTTPS.

  Frontend cleanup
  - Removed the isProduction() split in fetch/auth.ts — dev and production now use the same code path.
  - Removed all localStorage reads/writes for auth tokens and space ID.
  - withCredentials: true is now set globally on axios.
