### PR TITLE
fix: text explanation state

### DIFF
--- a/apps/spaces/src/components/TipTapEditor/EmailTipTapEditor.tsx
+++ b/apps/spaces/src/components/TipTapEditor/EmailTipTapEditor.tsx
@@ -51,9 +51,11 @@ export const EmailTipTapEditor = ({
   const links = useLink(editor)
   const tables = useTable(editor)
   const selectedImageExplanationIndex = images.getSelectedImageExplanationIndex()
+
   const isExplanationButtonSelected =
     explanations.isTextExplanationSelected() ||
-    selectedImageExplanationIndex === explanations.selectedExplanation
+    (selectedImageExplanationIndex !== null &&
+      selectedImageExplanationIndex === explanations.selectedExplanation)
 
   // Connect editor events to hooks
   if (editor) {

--- a/apps/spaces/src/components/TipTapEditor/hooks/useExplanations.tsx
+++ b/apps/spaces/src/components/TipTapEditor/hooks/useExplanations.tsx
@@ -1,10 +1,12 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { shallow } from 'zustand/shallow'
 import { NodeSelection } from 'prosemirror-state'
 import { useStore } from '../../../store'
 import { subscribe, unsubscribe } from '../../../utils/customEvent'
 
 export const useExplanations = (editor: any, editorId: string) => {
+  const markExplanationsFrameRef = useRef<number | null>(null)
+
   const {
     changeSelected,
     selectedExplanation,
@@ -23,12 +25,100 @@ export const useExplanations = (editor: any, editorId: string) => {
     getExplanationIds: state.getExplanationIds,
   }), shallow)
 
-  
+  const getTextExplanationIndexFromSelection = useCallback(() => {
+    if (!editor) return null
+
+    const editorElement = document.getElementById(editorId)
+    const domSelection = typeof window !== 'undefined' ? window.getSelection() : null
+
+    if (editorElement && domSelection) {
+      const candidateNodes = [domSelection.anchorNode, domSelection.focusNode]
+
+      for (const candidateNode of candidateNodes) {
+        if (!candidateNode) continue
+
+        const candidateElement =
+          candidateNode instanceof Element ? candidateNode : candidateNode.parentElement
+
+        const explanationElement = candidateElement?.closest?.('mark[data-explanation]')
+        const explanationIndex = explanationElement?.getAttribute('data-explanation')
+
+        if (explanationElement && editorElement.contains(explanationElement) && explanationIndex) {
+          return Number(explanationIndex)
+        }
+      }
+    }
+
+    const { selection, storedMarks } = editor.state
+
+    const getExplanationIndexFromMarks = (marks = []) => {
+      const explanationMark = marks.find(mark => mark.type.name === 'explanation')
+      const explanationIndex = explanationMark?.attrs?.['data-explanation']
+
+      return explanationIndex ? Number(explanationIndex) : null
+    }
+
+    if (selection.from !== selection.to) {
+      let explanationIndex = null
+
+      editor.state.doc.nodesBetween(selection.from, selection.to, (node) => {
+        if (explanationIndex !== null) return false
+
+        explanationIndex = getExplanationIndexFromMarks(node.marks ?? [])
+        return explanationIndex === null
+      })
+
+      if (explanationIndex !== null) {
+        return explanationIndex
+      }
+    }
+
+    return (
+      getExplanationIndexFromMarks(selection.$from?.marks() ?? []) ??
+      getExplanationIndexFromMarks(selection.$to?.marks() ?? []) ??
+      getExplanationIndexFromMarks(selection.$from?.nodeAfter?.marks ?? []) ??
+      getExplanationIndexFromMarks(selection.$from?.nodeBefore?.marks ?? []) ??
+      getExplanationIndexFromMarks(selection.$to?.nodeAfter?.marks ?? []) ??
+      getExplanationIndexFromMarks(selection.$to?.nodeBefore?.marks ?? []) ??
+      getExplanationIndexFromMarks(storedMarks ?? [])
+    )
+  }, [editor, editorId])
+
+  const hasSelectedTextExplanation = useCallback(() => {
+    if (!editor || selectedExplanation === null) return false
+
+    let found = false
+
+    editor.state.doc.descendants((node) => {
+      if (found) {
+        return false
+      }
+
+      const hasMatchingExplanation = node.marks?.some(mark =>
+        mark.type.name === 'explanation' &&
+        Number(mark.attrs['data-explanation']) === selectedExplanation
+      )
+
+      if (hasMatchingExplanation) {
+        found = true
+        return false
+      }
+
+      return true
+    })
+
+    return found
+  }, [editor, selectedExplanation])
   const markExplanations = useCallback((selectedExplanation) => { 
     if (!editorId) return
     
     const explanations = document.getElementById(editorId)?.querySelectorAll('[data-explanation]')
     if (!explanations) return
+
+    if (markExplanationsFrameRef.current !== null) {
+      cancelAnimationFrame(markExplanationsFrameRef.current)
+      markExplanationsFrameRef.current = null
+    }
 
     explanations.forEach((e) => {        
       if (e.classList.contains('mark-active')) {
@@ -42,7 +132,7 @@ export const useExplanations = (editor: any, editorId: string) => {
       }
     })
 
-    setTimeout(() => {
+    markExplanationsFrameRef.current = requestAnimationFrame(() => {
       explanations.forEach((e) => {
         const dataExplanation = e.getAttribute('data-explanation')
         if (parseInt(dataExplanation) === +selectedExplanation) {          
@@ -53,7 +143,8 @@ export const useExplanations = (editor: any, editorId: string) => {
           }
         }
       })
-    }, 100)
+      markExplanationsFrameRef.current = null
+    })
   }, [editorId])
 
   const cleanDeletedExplanations = useCallback((deleteIndex) => {
@@ -137,29 +228,29 @@ export const useExplanations = (editor: any, editorId: string) => {
     const orphanedExplanations = storeExplanations.filter(explanation => 
       !activeExplanationIndexes.has(explanation.index)
     ) 
-
     orphanedExplanations.forEach(orphan => {
-      console.log(`Cleaning up orphaned explanation: ${orphan.index}`)
       deleteExplanation(orphan.index)
     })
-  }, [editor, storeExplanations, deleteExplanation])
+  }, [editor, storeExplanations, deleteExplanation, getExplanationIds])
 
   const handleSelectionUpdate = useCallback(() => {
     if (!editor) return
 
     const { selection } = editor.state
+
+    const selectedTextExplanationIndex = getTextExplanationIndexFromSelection()
     
-    if (editor.isActive('explanation')) {
-      const dataIndex = editor.getAttributes('explanation')['data-explanation']
-      if (dataIndex !== selectedExplanation) {
-        changeSelected(dataIndex)
+    if (selectedTextExplanationIndex !== null) {
+      if (selectedTextExplanationIndex !== selectedExplanation) {
+        changeSelected(selectedTextExplanationIndex)
       }
     } 
 
     else if (selection instanceof NodeSelection && selection.node.type.name === 'image') {
       const explanationIndex = selection.node.attrs['data-explanation']
-      if (explanationIndex && explanationIndex !== selectedExplanation) {
-        changeSelected(explanationIndex)
+      const normalizedExplanationIndex = explanationIndex ? Number(explanationIndex) : null
+      if (normalizedExplanationIndex && normalizedExplanationIndex !== selectedExplanation) {
+        changeSelected(normalizedExplanationIndex)
       } else if (!explanationIndex && selectedExplanation !== null) {
         changeSelected(null)
       }
@@ -169,14 +260,14 @@ export const useExplanations = (editor: any, editorId: string) => {
         changeSelected(null)
       }
     }
-  }, [editor, selectedExplanation, changeSelected])
+  }, [editor, selectedExplanation, changeSelected, getTextExplanationIndexFromSelection])
 
   const addTextExplanation = useCallback(() => {
     if (!editor) return false
 
     const { from, to } = editor.state.selection
     const hasSelection = from !== to
-    const canAdd = hasSelection && !editor.isActive('explanation')
+    const canAdd = hasSelection && getTextExplanationIndexFromSelection() === null
 
     if (canAdd) {
       const newIndex = explanationIndex + 1
@@ -187,16 +278,20 @@ export const useExplanations = (editor: any, editorId: string) => {
       return true
     }
     return false
-  }, [editor, explanationIndex, addExplanation])
+  }, [editor, explanationIndex, addExplanation, getTextExplanationIndexFromSelection])
 
   const removeTextExplanation = useCallback(() => {
-    if (!editor || !editor.isActive('explanation')) return false
-    const deleteIndex = editor.getAttributes('explanation')['data-explanation']
+    const activeExplanationIndex = getTextExplanationIndexFromSelection()
+
+    if (!editor || activeExplanationIndex === null) {
+      return false
+    }
+    const deleteIndex = activeExplanationIndex
     deleteExplanation(deleteIndex)
     cleanDeletedExplanations(deleteIndex)
     editor.chain().focus().unsetExplanation().run()
     return true
-  }, [editor, deleteExplanation])
+  }, [editor, deleteExplanation, cleanDeletedExplanations, getTextExplanationIndexFromSelection])
 
   const addImageExplanation = useCallback(() => {
     if (!editor) return false
@@ -240,24 +335,25 @@ export const useExplanations = (editor: any, editorId: string) => {
   const canAddTextExplanation = useCallback(() => {
     if (!editor) return false
     const { from, to } = editor.state.selection
-    return from !== to && !editor.isActive('explanation')
-  }, [editor])
+    return from !== to && getTextExplanationIndexFromSelection() === null
+  }, [editor, getTextExplanationIndexFromSelection])
 
   const getActiveTextExplanationIndex = useCallback(() => {
-    if (!editor?.isActive('explanation')) return null
-
-    const explanationIndex = editor.getAttributes('explanation')['data-explanation']
-    return explanationIndex ? Number(explanationIndex) : null
-  }, [editor])
+    return getTextExplanationIndexFromSelection()
+  }, [getTextExplanationIndexFromSelection])
 
   const isTextExplanationActive = useCallback(() => {
-    return editor?.isActive('explanation') || false
-  }, [editor])
+    return getTextExplanationIndexFromSelection() !== null
+  }, [getTextExplanationIndexFromSelection])
 
   const isTextExplanationSelected = useCallback(() => {
+    if (hasSelectedTextExplanation()) {
+      return true
+    }
+
     const explanationIndex = getActiveTextExplanationIndex()
     return explanationIndex !== null && explanationIndex === selectedExplanation
-  }, [getActiveTextExplanationIndex, selectedExplanation])
+  }, [getActiveTextExplanationIndex, hasSelectedTextExplanation, selectedExplanation])
 
   const hasAnyExplanation = useCallback(() => {
     if (!editor) return false
@@ -287,7 +383,6 @@ export const useExplanations = (editor: any, editorId: string) => {
     if (!editor) return
 
     const handleDeleteExplanation = (event) => {
-      console.log('EXECUTING SUBSCRIPTION')
       cleanDeletedExplanations(event.detail.deleteIndex)
     }
 
@@ -296,11 +391,44 @@ export const useExplanations = (editor: any, editorId: string) => {
     return () => {
       unsubscribe('delete-explanation', handleDeleteExplanation)
     }
-  }, [cleanDeletedExplanations])
+  }, [cleanDeletedExplanations, editor])
+
+  useEffect(() => {
+    const handlePointerDownOutside = (event: MouseEvent | PointerEvent) => {
+      if (selectedExplanation === null) return
+
+      const target = event.target
+      if (!(target instanceof Node)) return
+
+      const editorElement = document.getElementById(editorId)
+      const explanationsElement = document.getElementById('explanations-wrapper')
+
+      const isInsideEditor = Boolean(editorElement?.contains(target))
+      const isInsideExplanationsPanel = Boolean(explanationsElement?.contains(target))
+
+      if (!isInsideEditor && !isInsideExplanationsPanel) {
+        changeSelected(null)
+      }
+    }
+
+    document.addEventListener('pointerdown', handlePointerDownOutside)
+
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDownOutside)
+    }
+  }, [changeSelected, editorId, selectedExplanation])
 
   useEffect(() => {
     markExplanations(selectedExplanation)
   }, [selectedExplanation, markExplanations])
+
+  useEffect(() => {
+    return () => {
+      if (markExplanationsFrameRef.current !== null) {
+        cancelAnimationFrame(markExplanationsFrameRef.current)
+      }
+    }
+  }, [])
 
   return {
     selectedExplanation,

--- a/apps/spaces/src/components/TipTapEditor/hooks/useExplanations.tsx
+++ b/apps/spaces/src/components/TipTapEditor/hooks/useExplanations.tsx
@@ -22,7 +22,7 @@ export const useExplanations = (editor: any, editorId: string) => {
     deleteExplanation: state.deleteExplanation,
     addExplanation: state.addExplanation,
     explanationIndex: state.explanationIndex,
-    getExplanationIds: state.getExplanationIds
+    getExplanationIds: state.getExplanationIds,
   }), shallow)
 
   const getTextExplanationIndexFromSelection = useCallback(() => {
@@ -38,9 +38,7 @@ export const useExplanations = (editor: any, editorId: string) => {
         if (!candidateNode) continue
 
         const candidateElement =
-          candidateNode instanceof Element
-            ? candidateNode
-            : candidateNode.parentElement
+          candidateNode instanceof Element ? candidateNode : candidateNode.parentElement
 
         const explanationElement = candidateElement?.closest?.('mark[data-explanation]')
         const explanationIndex = explanationElement?.getAttribute('data-explanation')
@@ -86,9 +84,34 @@ export const useExplanations = (editor: any, editorId: string) => {
     )
   }, [editor, editorId])
 
-  const markExplanations = useCallback((selectedExplanation) => {
-    if (!editorId) return
+  const hasSelectedTextExplanation = useCallback(() => {
+    if (!editor || selectedExplanation === null) return false
 
+    let found = false
+
+    editor.state.doc.descendants((node) => {
+      if (found) {
+        return false
+      }
+
+      const hasMatchingExplanation = node.marks?.some(mark =>
+        mark.type.name === 'explanation' &&
+        Number(mark.attrs['data-explanation']) === selectedExplanation
+      )
+
+      if (hasMatchingExplanation) {
+        found = true
+        return false
+      }
+
+      return true
+    })
+
+    return found
+  }, [editor, selectedExplanation])
+  const markExplanations = useCallback((selectedExplanation) => { 
+    if (!editorId) return
+    
     const explanations = document.getElementById(editorId)?.querySelectorAll('[data-explanation]')
     if (!explanations) return
 
@@ -97,56 +120,63 @@ export const useExplanations = (editor: any, editorId: string) => {
       markExplanationsFrameRef.current = null
     }
 
-    explanations.forEach((element) => {
-      element.classList.remove('mark-active')
+    explanations.forEach((e) => {        
+      if (e.classList.contains('mark-active')) {
+        e.classList.remove('mark-active')
+      }
 
-      if (element.tagName === 'IMG' && element instanceof HTMLElement && element.classList.contains('has-explanation')) {
-        element.style.border = '2px solid #F3F9CF'
+      if (e.tagName === 'IMG' && e instanceof HTMLElement) {
+        if (e.classList.contains('has-explanation')) {
+          e.style.border = '2px solid #F3F9CF'
+        }
       }
     })
 
     markExplanationsFrameRef.current = requestAnimationFrame(() => {
-      explanations.forEach((element) => {
-        const explanationIndex = element.getAttribute('data-explanation')
+      explanations.forEach((e) => {
+        const dataExplanation = e.getAttribute('data-explanation')
+        if (parseInt(dataExplanation) === +selectedExplanation) {          
+          e.classList.add('mark-active')
 
-        if (selectedExplanation !== null && Number(explanationIndex) === selectedExplanation) {
-          element.classList.add('mark-active')
-
-          if (element.tagName === 'IMG' && element instanceof HTMLElement) {
-            element.style.border = '2px solid #FCC934'
+          if (e.tagName === 'IMG' && e instanceof HTMLElement) {
+            e.style.border = '2px solid #FCC934'
           }
         }
       })
-
       markExplanationsFrameRef.current = null
     })
   }, [editorId])
 
   const cleanDeletedExplanations = useCallback((deleteIndex) => {
     if (!editor) return
-
+    
     const { tr } = editor.state
     let hasChanges = false
 
     editor.state.doc.descendants((node, pos) => {
       if (node.isText) {
         node.marks.forEach(mark => {
-          if (Number(mark.attrs['data-explanation']) === deleteIndex) {
+          if (mark.attrs['data-explanation'] === +deleteIndex) {
             tr.removeMark(pos, pos + node.nodeSize, mark.type)
             hasChanges = true
           }
         })
       }
-
-      if (
-        ['image', 'tableCell', 'tableHeader'].includes(node.type.name) &&
-        Number(node.attrs['data-explanation']) === deleteIndex
-      ) {
+      
+      if (node.type.name === 'image' && node.attrs['data-explanation'] === +deleteIndex) {
         tr.setNodeMarkup(pos, null, {
           ...node.attrs,
           'data-explanation': null
         })
+        hasChanges = true
+      }
 
+      if ((node.type.name === 'tableCell' || node.type.name === 'tableHeader') && 
+          node.attrs['data-explanation'] === +deleteIndex) {
+        tr.setNodeMarkup(pos, null, {
+          ...node.attrs,
+          'data-explanation': null
+        })
         hasChanges = true
       }
     })
@@ -158,48 +188,46 @@ export const useExplanations = (editor: any, editorId: string) => {
 
   const cleanupOrphanedExplanations = useCallback(() => {
     if (!editor) return
-
-    const editorExplanationIndexes = new Set<number>()
-
+    
+    
+    const editorExplanationIndexes = new Set()
+    
+    // first, get explanations from this editor
+    // TODO Why the distinction of types is necessary ?
     editor.state.doc.descendants((node) => {
       node.marks.forEach(mark => {
-        const explanationIndex = mark.attrs['data-explanation']
-
-        if (explanationIndex) {
-          editorExplanationIndexes.add(Number(explanationIndex))
+        if (mark.attrs['data-explanation']) {
+          editorExplanationIndexes.add(parseInt(mark.attrs['data-explanation']))
         }
       })
+      
+      if (node.type.name === 'image' && node.attrs['data-explanation']) {
+        editorExplanationIndexes.add(parseInt(node.attrs['data-explanation']))
+      }
 
-      const nodeExplanationIndex = node.attrs?.['data-explanation']
-
-      if (
-        ['image', 'tableCell', 'tableHeader'].includes(node.type.name) &&
-        nodeExplanationIndex
-      ) {
-        editorExplanationIndexes.add(Number(nodeExplanationIndex))
+      if ((node.type.name === 'tableCell' || node.type.name === 'tableHeader') && node.attrs['data-explanation']) {
+        editorExplanationIndexes.add(parseInt(node.attrs['data-explanation']))
       }
     })
 
-    document.querySelectorAll('[id*="component-text"]').forEach((component) => {
-      component.querySelectorAll('[data-explanation]').forEach((explanation) => {
-        const explanationIndex = explanation.getAttribute('data-explanation')
-
-        if (explanationIndex) {
-          editorExplanationIndexes.add(Number(explanationIndex))
-        }
+    // get all editor explanations
+    document.querySelectorAll('[id*="component-text"]').forEach((ca) => {
+      ca.querySelectorAll('[data-explanation]').forEach((de) => {
+          const explanationIndex = de.getAttribute('data-explanation')
+          if (explanationIndex && !editorExplanationIndexes.has(explanationIndex)) {
+            editorExplanationIndexes.add(parseInt(explanationIndex))
+          }           
       })
     })
 
-    const activeQuestionIds = getExplanationIds()
-    const activeExplanationIndexes = new Set([
-      ...activeQuestionIds,
-      ...editorExplanationIndexes
-    ])
+    // second, add explanations on activequestion
+    const activeQuestionIds = getExplanationIds()   
+    const activeExplanationIndexes = new Set([...activeQuestionIds, ...editorExplanationIndexes]) 
 
-    const orphanedExplanations = storeExplanations.filter(explanation =>
+
+    const orphanedExplanations = storeExplanations.filter(explanation => 
       !activeExplanationIndexes.has(explanation.index)
-    )
-
+    ) 
     orphanedExplanations.forEach(orphan => {
       deleteExplanation(orphan.index)
     })
@@ -209,31 +237,28 @@ export const useExplanations = (editor: any, editorId: string) => {
     if (!editor) return
 
     const { selection } = editor.state
-    const selectedTextExplanationIndex = getTextExplanationIndexFromSelection()
 
+    const selectedTextExplanationIndex = getTextExplanationIndexFromSelection()
+    
     if (selectedTextExplanationIndex !== null) {
       if (selectedTextExplanationIndex !== selectedExplanation) {
         changeSelected(selectedTextExplanationIndex)
       }
+    } 
 
-      return
-    }
-
-    if (selection instanceof NodeSelection && selection.node.type.name === 'image') {
+    else if (selection instanceof NodeSelection && selection.node.type.name === 'image') {
       const explanationIndex = selection.node.attrs['data-explanation']
       const normalizedExplanationIndex = explanationIndex ? Number(explanationIndex) : null
-
-      if (normalizedExplanationIndex !== null && normalizedExplanationIndex !== selectedExplanation) {
+      if (normalizedExplanationIndex && normalizedExplanationIndex !== selectedExplanation) {
         changeSelected(normalizedExplanationIndex)
-      } else if (normalizedExplanationIndex === null && selectedExplanation !== null) {
+      } else if (!explanationIndex && selectedExplanation !== null) {
         changeSelected(null)
       }
-
-      return
-    }
-
-    if (selectedExplanation !== null) {
-      changeSelected(null)
+    } 
+    else {
+      if (selectedExplanation !== null) {
+        changeSelected(null)
+      }
     }
   }, [editor, selectedExplanation, changeSelected, getTextExplanationIndexFromSelection])
 
@@ -244,32 +269,27 @@ export const useExplanations = (editor: any, editorId: string) => {
     const hasSelection = from !== to
     const canAdd = hasSelection && getTextExplanationIndexFromSelection() === null
 
-    if (!canAdd) return false
-
-    const newIndex = explanationIndex + 1
-
-    editor.chain().focus().setExplanation({
-      'data-explanation': newIndex
-    }).run()
-
-    addExplanation(newIndex)
-
-    return true
+    if (canAdd) {
+      const newIndex = explanationIndex + 1
+      editor.chain().focus().setExplanation({
+        'data-explanation': newIndex,
+      }).run()
+      addExplanation(newIndex)
+      return true
+    }
+    return false
   }, [editor, explanationIndex, addExplanation, getTextExplanationIndexFromSelection])
 
   const removeTextExplanation = useCallback(() => {
-    if (!editor) return false
+    const activeExplanationIndex = getTextExplanationIndexFromSelection()
 
-    const deleteIndex = getTextExplanationIndexFromSelection()
-
-    if (deleteIndex === null) {
+    if (!editor || activeExplanationIndex === null) {
       return false
     }
-
+    const deleteIndex = activeExplanationIndex
     deleteExplanation(deleteIndex)
     cleanDeletedExplanations(deleteIndex)
     editor.chain().focus().unsetExplanation().run()
-
     return true
   }, [editor, deleteExplanation, cleanDeletedExplanations, getTextExplanationIndexFromSelection])
 
@@ -277,19 +297,17 @@ export const useExplanations = (editor: any, editorId: string) => {
     if (!editor) return false
 
     const { selection } = editor.state
-
+    
     if (selection instanceof NodeSelection && selection.node.type.name === 'image') {
       const newIndex = explanationIndex + 1
-
+      
       editor.chain().focus().updateAttributes('image', {
         'data-explanation': newIndex
       }).run()
-
+      
       addExplanation(newIndex, 'Image')
-
       return true
     }
-
     return false
   }, [editor, explanationIndex, addExplanation])
 
@@ -297,31 +315,26 @@ export const useExplanations = (editor: any, editorId: string) => {
     if (!editor) return false
 
     const { selection } = editor.state
-
-    if (
-      selection instanceof NodeSelection &&
-      selection.node.type.name === 'image' &&
-      selection.node.attrs['data-explanation']
-    ) {
+    
+    if (selection instanceof NodeSelection && 
+        selection.node.type.name === 'image' && 
+        selection.node.attrs['data-explanation']) {
+      
       const explanationIndex = selection.node.attrs['data-explanation']
-
+      
       editor.chain().focus().updateAttributes('image', {
         'data-explanation': null
       }).run()
-
+      
       deleteExplanation(explanationIndex)
-
       return true
     }
-
     return false
   }, [editor, deleteExplanation])
 
   const canAddTextExplanation = useCallback(() => {
     if (!editor) return false
-
     const { from, to } = editor.state.selection
-
     return from !== to && getTextExplanationIndexFromSelection() === null
   }, [editor, getTextExplanationIndexFromSelection])
 
@@ -334,8 +347,13 @@ export const useExplanations = (editor: any, editorId: string) => {
   }, [getTextExplanationIndexFromSelection])
 
   const isTextExplanationSelected = useCallback(() => {
-    return getActiveTextExplanationIndex() === selectedExplanation
-  }, [getActiveTextExplanationIndex, selectedExplanation])
+    if (hasSelectedTextExplanation()) {
+      return true
+    }
+
+    const explanationIndex = getActiveTextExplanationIndex()
+    return explanationIndex !== null && explanationIndex === selectedExplanation
+  }, [getActiveTextExplanationIndex, hasSelectedTextExplanation, selectedExplanation])
 
   const hasAnyExplanation = useCallback(() => {
     if (!editor) return false
@@ -347,9 +365,7 @@ export const useExplanations = (editor: any, editorId: string) => {
         return false
       }
 
-      const hasMarkedExplanation = node.marks?.some(mark =>
-        Boolean(mark.attrs['data-explanation'])
-      )
+      const hasMarkedExplanation = node.marks?.some(mark => Boolean(mark.attrs['data-explanation']))
       const hasNodeExplanation = Boolean(node.attrs?.['data-explanation'])
 
       if (hasMarkedExplanation || hasNodeExplanation) {
@@ -382,7 +398,6 @@ export const useExplanations = (editor: any, editorId: string) => {
       if (selectedExplanation === null) return
 
       const target = event.target
-
       if (!(target instanceof Node)) return
 
       const editorElement = document.getElementById(editorId)

--- a/apps/spaces/src/components/TipTapEditor/hooks/useExplanations.tsx
+++ b/apps/spaces/src/components/TipTapEditor/hooks/useExplanations.tsx
@@ -22,7 +22,7 @@ export const useExplanations = (editor: any, editorId: string) => {
     deleteExplanation: state.deleteExplanation,
     addExplanation: state.addExplanation,
     explanationIndex: state.explanationIndex,
-    getExplanationIds: state.getExplanationIds,
+    getExplanationIds: state.getExplanationIds
   }), shallow)
 
   const getTextExplanationIndexFromSelection = useCallback(() => {
@@ -38,7 +38,9 @@ export const useExplanations = (editor: any, editorId: string) => {
         if (!candidateNode) continue
 
         const candidateElement =
-          candidateNode instanceof Element ? candidateNode : candidateNode.parentElement
+          candidateNode instanceof Element
+            ? candidateNode
+            : candidateNode.parentElement
 
         const explanationElement = candidateElement?.closest?.('mark[data-explanation]')
         const explanationIndex = explanationElement?.getAttribute('data-explanation')
@@ -84,34 +86,9 @@ export const useExplanations = (editor: any, editorId: string) => {
     )
   }, [editor, editorId])
 
-  const hasSelectedTextExplanation = useCallback(() => {
-    if (!editor || selectedExplanation === null) return false
-
-    let found = false
-
-    editor.state.doc.descendants((node) => {
-      if (found) {
-        return false
-      }
-
-      const hasMatchingExplanation = node.marks?.some(mark =>
-        mark.type.name === 'explanation' &&
-        Number(mark.attrs['data-explanation']) === selectedExplanation
-      )
-
-      if (hasMatchingExplanation) {
-        found = true
-        return false
-      }
-
-      return true
-    })
-
-    return found
-  }, [editor, selectedExplanation])
-  const markExplanations = useCallback((selectedExplanation) => { 
+  const markExplanations = useCallback((selectedExplanation) => {
     if (!editorId) return
-    
+
     const explanations = document.getElementById(editorId)?.querySelectorAll('[data-explanation]')
     if (!explanations) return
 
@@ -120,63 +97,56 @@ export const useExplanations = (editor: any, editorId: string) => {
       markExplanationsFrameRef.current = null
     }
 
-    explanations.forEach((e) => {        
-      if (e.classList.contains('mark-active')) {
-        e.classList.remove('mark-active')
-      }
+    explanations.forEach((element) => {
+      element.classList.remove('mark-active')
 
-      if (e.tagName === 'IMG' && e instanceof HTMLElement) {
-        if (e.classList.contains('has-explanation')) {
-          e.style.border = '2px solid #F3F9CF'
-        }
+      if (element.tagName === 'IMG' && element instanceof HTMLElement && element.classList.contains('has-explanation')) {
+        element.style.border = '2px solid #F3F9CF'
       }
     })
 
     markExplanationsFrameRef.current = requestAnimationFrame(() => {
-      explanations.forEach((e) => {
-        const dataExplanation = e.getAttribute('data-explanation')
-        if (parseInt(dataExplanation) === +selectedExplanation) {          
-          e.classList.add('mark-active')
+      explanations.forEach((element) => {
+        const explanationIndex = element.getAttribute('data-explanation')
 
-          if (e.tagName === 'IMG' && e instanceof HTMLElement) {
-            e.style.border = '2px solid #FCC934'
+        if (selectedExplanation !== null && Number(explanationIndex) === selectedExplanation) {
+          element.classList.add('mark-active')
+
+          if (element.tagName === 'IMG' && element instanceof HTMLElement) {
+            element.style.border = '2px solid #FCC934'
           }
         }
       })
+
       markExplanationsFrameRef.current = null
     })
   }, [editorId])
 
   const cleanDeletedExplanations = useCallback((deleteIndex) => {
     if (!editor) return
-    
+
     const { tr } = editor.state
     let hasChanges = false
 
     editor.state.doc.descendants((node, pos) => {
       if (node.isText) {
         node.marks.forEach(mark => {
-          if (mark.attrs['data-explanation'] === +deleteIndex) {
+          if (Number(mark.attrs['data-explanation']) === deleteIndex) {
             tr.removeMark(pos, pos + node.nodeSize, mark.type)
             hasChanges = true
           }
         })
       }
-      
-      if (node.type.name === 'image' && node.attrs['data-explanation'] === +deleteIndex) {
-        tr.setNodeMarkup(pos, null, {
-          ...node.attrs,
-          'data-explanation': null
-        })
-        hasChanges = true
-      }
 
-      if ((node.type.name === 'tableCell' || node.type.name === 'tableHeader') && 
-          node.attrs['data-explanation'] === +deleteIndex) {
+      if (
+        ['image', 'tableCell', 'tableHeader'].includes(node.type.name) &&
+        Number(node.attrs['data-explanation']) === deleteIndex
+      ) {
         tr.setNodeMarkup(pos, null, {
           ...node.attrs,
           'data-explanation': null
         })
+
         hasChanges = true
       }
     })
@@ -188,46 +158,48 @@ export const useExplanations = (editor: any, editorId: string) => {
 
   const cleanupOrphanedExplanations = useCallback(() => {
     if (!editor) return
-    
-    
-    const editorExplanationIndexes = new Set()
-    
-    // first, get explanations from this editor
-    // TODO Why the distinction of types is necessary ?
+
+    const editorExplanationIndexes = new Set<number>()
+
     editor.state.doc.descendants((node) => {
       node.marks.forEach(mark => {
-        if (mark.attrs['data-explanation']) {
-          editorExplanationIndexes.add(parseInt(mark.attrs['data-explanation']))
+        const explanationIndex = mark.attrs['data-explanation']
+
+        if (explanationIndex) {
+          editorExplanationIndexes.add(Number(explanationIndex))
         }
       })
-      
-      if (node.type.name === 'image' && node.attrs['data-explanation']) {
-        editorExplanationIndexes.add(parseInt(node.attrs['data-explanation']))
-      }
 
-      if ((node.type.name === 'tableCell' || node.type.name === 'tableHeader') && node.attrs['data-explanation']) {
-        editorExplanationIndexes.add(parseInt(node.attrs['data-explanation']))
+      const nodeExplanationIndex = node.attrs?.['data-explanation']
+
+      if (
+        ['image', 'tableCell', 'tableHeader'].includes(node.type.name) &&
+        nodeExplanationIndex
+      ) {
+        editorExplanationIndexes.add(Number(nodeExplanationIndex))
       }
     })
 
-    // get all editor explanations
-    document.querySelectorAll('[id*="component-text"]').forEach((ca) => {
-      ca.querySelectorAll('[data-explanation]').forEach((de) => {
-          const explanationIndex = de.getAttribute('data-explanation')
-          if (explanationIndex && !editorExplanationIndexes.has(explanationIndex)) {
-            editorExplanationIndexes.add(parseInt(explanationIndex))
-          }           
+    document.querySelectorAll('[id*="component-text"]').forEach((component) => {
+      component.querySelectorAll('[data-explanation]').forEach((explanation) => {
+        const explanationIndex = explanation.getAttribute('data-explanation')
+
+        if (explanationIndex) {
+          editorExplanationIndexes.add(Number(explanationIndex))
+        }
       })
     })
 
-    // second, add explanations on activequestion
-    const activeQuestionIds = getExplanationIds()   
-    const activeExplanationIndexes = new Set([...activeQuestionIds, ...editorExplanationIndexes]) 
+    const activeQuestionIds = getExplanationIds()
+    const activeExplanationIndexes = new Set([
+      ...activeQuestionIds,
+      ...editorExplanationIndexes
+    ])
 
-
-    const orphanedExplanations = storeExplanations.filter(explanation => 
+    const orphanedExplanations = storeExplanations.filter(explanation =>
       !activeExplanationIndexes.has(explanation.index)
-    ) 
+    )
+
     orphanedExplanations.forEach(orphan => {
       deleteExplanation(orphan.index)
     })
@@ -237,28 +209,31 @@ export const useExplanations = (editor: any, editorId: string) => {
     if (!editor) return
 
     const { selection } = editor.state
-
     const selectedTextExplanationIndex = getTextExplanationIndexFromSelection()
-    
+
     if (selectedTextExplanationIndex !== null) {
       if (selectedTextExplanationIndex !== selectedExplanation) {
         changeSelected(selectedTextExplanationIndex)
       }
-    } 
 
-    else if (selection instanceof NodeSelection && selection.node.type.name === 'image') {
+      return
+    }
+
+    if (selection instanceof NodeSelection && selection.node.type.name === 'image') {
       const explanationIndex = selection.node.attrs['data-explanation']
       const normalizedExplanationIndex = explanationIndex ? Number(explanationIndex) : null
-      if (normalizedExplanationIndex && normalizedExplanationIndex !== selectedExplanation) {
+
+      if (normalizedExplanationIndex !== null && normalizedExplanationIndex !== selectedExplanation) {
         changeSelected(normalizedExplanationIndex)
-      } else if (!explanationIndex && selectedExplanation !== null) {
+      } else if (normalizedExplanationIndex === null && selectedExplanation !== null) {
         changeSelected(null)
       }
-    } 
-    else {
-      if (selectedExplanation !== null) {
-        changeSelected(null)
-      }
+
+      return
+    }
+
+    if (selectedExplanation !== null) {
+      changeSelected(null)
     }
   }, [editor, selectedExplanation, changeSelected, getTextExplanationIndexFromSelection])
 
@@ -269,27 +244,32 @@ export const useExplanations = (editor: any, editorId: string) => {
     const hasSelection = from !== to
     const canAdd = hasSelection && getTextExplanationIndexFromSelection() === null
 
-    if (canAdd) {
-      const newIndex = explanationIndex + 1
-      editor.chain().focus().setExplanation({
-        'data-explanation': newIndex,
-      }).run()
-      addExplanation(newIndex)
-      return true
-    }
-    return false
+    if (!canAdd) return false
+
+    const newIndex = explanationIndex + 1
+
+    editor.chain().focus().setExplanation({
+      'data-explanation': newIndex
+    }).run()
+
+    addExplanation(newIndex)
+
+    return true
   }, [editor, explanationIndex, addExplanation, getTextExplanationIndexFromSelection])
 
   const removeTextExplanation = useCallback(() => {
-    const activeExplanationIndex = getTextExplanationIndexFromSelection()
+    if (!editor) return false
 
-    if (!editor || activeExplanationIndex === null) {
+    const deleteIndex = getTextExplanationIndexFromSelection()
+
+    if (deleteIndex === null) {
       return false
     }
-    const deleteIndex = activeExplanationIndex
+
     deleteExplanation(deleteIndex)
     cleanDeletedExplanations(deleteIndex)
     editor.chain().focus().unsetExplanation().run()
+
     return true
   }, [editor, deleteExplanation, cleanDeletedExplanations, getTextExplanationIndexFromSelection])
 
@@ -297,17 +277,19 @@ export const useExplanations = (editor: any, editorId: string) => {
     if (!editor) return false
 
     const { selection } = editor.state
-    
+
     if (selection instanceof NodeSelection && selection.node.type.name === 'image') {
       const newIndex = explanationIndex + 1
-      
+
       editor.chain().focus().updateAttributes('image', {
         'data-explanation': newIndex
       }).run()
-      
+
       addExplanation(newIndex, 'Image')
+
       return true
     }
+
     return false
   }, [editor, explanationIndex, addExplanation])
 
@@ -315,26 +297,31 @@ export const useExplanations = (editor: any, editorId: string) => {
     if (!editor) return false
 
     const { selection } = editor.state
-    
-    if (selection instanceof NodeSelection && 
-        selection.node.type.name === 'image' && 
-        selection.node.attrs['data-explanation']) {
-      
+
+    if (
+      selection instanceof NodeSelection &&
+      selection.node.type.name === 'image' &&
+      selection.node.attrs['data-explanation']
+    ) {
       const explanationIndex = selection.node.attrs['data-explanation']
-      
+
       editor.chain().focus().updateAttributes('image', {
         'data-explanation': null
       }).run()
-      
+
       deleteExplanation(explanationIndex)
+
       return true
     }
+
     return false
   }, [editor, deleteExplanation])
 
   const canAddTextExplanation = useCallback(() => {
     if (!editor) return false
+
     const { from, to } = editor.state.selection
+
     return from !== to && getTextExplanationIndexFromSelection() === null
   }, [editor, getTextExplanationIndexFromSelection])
 
@@ -347,13 +334,8 @@ export const useExplanations = (editor: any, editorId: string) => {
   }, [getTextExplanationIndexFromSelection])
 
   const isTextExplanationSelected = useCallback(() => {
-    if (hasSelectedTextExplanation()) {
-      return true
-    }
-
-    const explanationIndex = getActiveTextExplanationIndex()
-    return explanationIndex !== null && explanationIndex === selectedExplanation
-  }, [getActiveTextExplanationIndex, hasSelectedTextExplanation, selectedExplanation])
+    return getActiveTextExplanationIndex() === selectedExplanation
+  }, [getActiveTextExplanationIndex, selectedExplanation])
 
   const hasAnyExplanation = useCallback(() => {
     if (!editor) return false
@@ -365,7 +347,9 @@ export const useExplanations = (editor: any, editorId: string) => {
         return false
       }
 
-      const hasMarkedExplanation = node.marks?.some(mark => Boolean(mark.attrs['data-explanation']))
+      const hasMarkedExplanation = node.marks?.some(mark =>
+        Boolean(mark.attrs['data-explanation'])
+      )
       const hasNodeExplanation = Boolean(node.attrs?.['data-explanation'])
 
       if (hasMarkedExplanation || hasNodeExplanation) {
@@ -398,6 +382,7 @@ export const useExplanations = (editor: any, editorId: string) => {
       if (selectedExplanation === null) return
 
       const target = event.target
+
       if (!(target instanceof Node)) return
 
       const editorElement = document.getElementById(editorId)

--- a/apps/spaces/src/store/slices/explanation.ts
+++ b/apps/spaces/src/store/slices/explanation.ts
@@ -10,7 +10,7 @@ export interface Explanation {
 
 export interface ExplanationsSlice {
   explanations: Explanation[],
-  selectedExplanation: number;
+  selectedExplanation: number | null;
   // last explanation index
   explanationIndex: number;
   addExplanation: (index: number, title?: string) => void
@@ -19,7 +19,7 @@ export interface ExplanationsSlice {
   updateExplanations: (explanations: Explanation[]) => void
   deleteExplanation: (index: number) => void
   deleteExplanations: (componentId: number, componentType: string) => void
-  changeSelected: (index: number) => void
+  changeSelected: (index: number | null) => void
   clearExplanations: () => void
 }
 
@@ -30,7 +30,7 @@ export const createExplanationsSlice: StateCreator<
   ExplanationsSlice
 > = (set, get) => ({
   explanations: [],
-  selectedExplanation: 0,
+  selectedExplanation: null,
   explanationIndex: 0,
   addExplanation: (index, title) => {
     set((state) => ({
@@ -51,7 +51,7 @@ export const createExplanationsSlice: StateCreator<
     set(() => ({
       explanations,
       explanationIndex: +(explanations.reduce((prev, curr) => prev.index > curr.index ? prev : curr).index),
-      selectedExplanation: explanations.length
+      selectedExplanation: null
     }))
   },
   deleteExplanation: (index) => {
@@ -96,7 +96,7 @@ export const createExplanationsSlice: StateCreator<
   clearExplanations: () => {
     set((state) => ({
       explanations: [],
-      selectedExplanation: 0,
+      selectedExplanation: null,
       explanationIndex: 0,
     }))
   },

--- a/packages/shira-ui/src/components/ExplanationButton/ExplanationButtonStyled.tsx
+++ b/packages/shira-ui/src/components/ExplanationButton/ExplanationButtonStyled.tsx
@@ -117,6 +117,14 @@ export const FilledIconButton = styled(BaseButton) <BaseProps>`
        stroke: ${props.theme.colors.green3};
       }
     `}
+
+    &[aria-pressed='true'] {
+      color: ${props => props.theme.colors.green4};
+
+      > svg {
+        stroke: ${props => props.theme.colors.green3};
+      }
+    }
   }
 `
 
@@ -175,5 +183,9 @@ export const TextFilledIconButton = styled(BaseButton) <BaseProps>`
     ${props => props.$active && `
       outline: solid 2px ${props.theme.colors.green3};
     `}
+
+    &[aria-pressed='true'] {
+      outline: solid 2px ${props => props.theme.colors.green3};
+    }
   }
 `

--- a/packages/shira-ui/src/components/ExplanationButton/ExplanationButtonStyled.tsx
+++ b/packages/shira-ui/src/components/ExplanationButton/ExplanationButtonStyled.tsx
@@ -124,8 +124,8 @@ const activeTextStates = css`
   &:hover {
     color: ${props => props.theme.colors.green4};
   }
-   
-  &:focus {
+
+  &:focus-visible {
     outline: solid 2px ${props => props.theme.colors.green2};
   }
 


### PR DESCRIPTION
#### Description
- `selectedExplanation` can now be null, before it was defaulted to 0
- Now clicking outside clears the selected text explanation

#### Task
https://app.asana.com/1/1155076882573518/project/1211894767921465/task/1213450496004207