### PR TITLE
hotfix/images-mishandling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ output-file.txt
 a-different-file.txt
 dist
 storybook-static
-public
+#public
 
 # Debug
 npm-debug.log*

--- a/apps/api/src/modules/question_library/services/duplicate-question-library.service.ts
+++ b/apps/api/src/modules/question_library/services/duplicate-question-library.service.ts
@@ -66,9 +66,41 @@ export class DuplicateLibraryQuestionService implements IDuplicateLibraryQuestio
         .andWhere('qt.language_id = :lid', { lid: selectedLanguageId })
         .getOne();
 
+      // Images
+      const imageIdMap = new Map<number, number>()
+
+      for (const originalImage of originalQuestion.images ?? []) {
+        const timestamp = Date.now();
+        const originalFileName = (originalImage.relativePath.split("/").pop() ?? "image").trim();
+        const hasDot = originalFileName.includes(".");
+        const fileExtension = hasDot ? originalFileName.split(".").pop() : "png";
+        const baseFileName = hasDot
+          ? originalFileName.replace(`.${fileExtension}`, "")
+          : originalFileName;
+        const newFileName = `${timestamp}_copy_${baseFileName}.${fileExtension}`;
+        const newImagePath = `question-images/${quizId}/${newFileName}`;
+
+        const newImage = manager.create(QuestionImage, {
+          name: originalImage.name,
+          relativePath: newImagePath,
+          question: savedQuestion,
+          quizId: quizId,
+        });
+
+        const savedImage = await manager.save(QuestionImage, newImage);
+        imageIdMap.set(originalImage.id, savedImage.id)
+
+        await this.imageService.copyAndDeleteOrigin(originalImage.relativePath, newImagePath);
+      }
+
+
       if (questionTranslation) {
+        let content = questionTranslation?.content || ""
+        for (const [oldId, newId] of imageIdMap) {
+          content = content.replace(new RegExp(`data-image-id="${oldId}"`, 'g'), `data-image-id="${newId}"`)
+        }
         const newTranslation = manager.create(QuestionTranslation, {
-          content: questionTranslation?.content || "",
+          content,
           question: savedQuestion,
           languageId: defaultLanguage.id
         });
@@ -110,34 +142,6 @@ export class DuplicateLibraryQuestionService implements IDuplicateLibraryQuestio
               languageId: defaultLanguage.id,
             }));
         }
-      }
-
-
-      // Images
-      const newImageIds = [];
-
-      for (const originalImage of originalQuestion.images ?? []) {
-        const timestamp = Date.now();
-        const originalFileName = (originalImage.relativePath.split("/").pop() ?? "image").trim();
-        const hasDot = originalFileName.includes(".");
-        const fileExtension = hasDot ? originalFileName.split(".").pop() : "png";
-        const baseFileName = hasDot
-          ? originalFileName.replace(`.${fileExtension}`, "")
-          : originalFileName;
-        const newFileName = `${timestamp}_copy_${baseFileName}.${fileExtension}`;
-        const newImagePath = `question-images/${quizId}/${newFileName}`;
-
-        const newImage = manager.create(QuestionImage, {
-          name: originalImage.name,
-          relativePath: newImagePath,
-          question: savedQuestion,
-          quizId: quizId,
-        });
-
-        const savedImage = await manager.save(QuestionImage, newImage);
-        newImageIds.push(savedImage.id);
-
-        await this.imageService.copyAndDeleteOrigin(originalImage.relativePath, newImagePath);
       }
 
 

--- a/apps/api/src/modules/quiz/services/shared-question-duplication.service.ts
+++ b/apps/api/src/modules/quiz/services/shared-question-duplication.service.ts
@@ -40,13 +40,33 @@ export class SharedQuestionDuplicationService implements ISharedQuestionDuplicat
 
     const savedQuestion = await manager.save(Question, newQuestion);
 
+    const imageIdMap = new Map<number, number>()
+    const newImageIds = []
+    for (const originalImage of originalQuestion.images) {
+      const newImagePath = this.generateNewImagePath(originalImage.relativePath, targetQuizId)
+      const newImage = manager.create(QuestionImage, {
+        name: originalImage.name,
+        relativePath: newImagePath,
+        question: savedQuestion,
+        quizId: targetQuizId
+      })
+      const savedImage = await manager.save(QuestionImage, newImage)
+      imageIdMap.set(originalImage.id, savedImage.id)
+      newImageIds.push(savedImage.id)
+      await this.imageService.copyAndDeleteOrigin(originalImage.relativePath, newImagePath)
+    }
+
     for (const translation of originalQuestion.questionTranslations) {
+      let content = translation.content
+      for (const [oldId, newId] of imageIdMap) {
+        content = content.replace(new RegExp(`data-image-id="${oldId}"`, 'g'), `data-image-id="${newId}"`)
+      }
       const newTranslation = manager.create(QuestionTranslation, {
-        content: translation.content,
+        content,
         question: savedQuestion,
         languageId: translation.languageId || defaultLanguage.id
-      });
-      await manager.save(QuestionTranslation, newTranslation);
+      })
+      await manager.save(QuestionTranslation, newTranslation)
     }
 
     for (const explanation of originalQuestion.explanations) {
@@ -67,23 +87,6 @@ export class SharedQuestionDuplicationService implements ISharedQuestionDuplicat
         });
         await manager.save(ExplanationTranslation, newExplanationTranslation);
       }
-    }
-
-    const newImageIds = [];
-    for (const originalImage of originalQuestion.images) {
-      const newImagePath = this.generateNewImagePath(originalImage.relativePath, targetQuizId);
-
-      const newImage = manager.create(QuestionImage, {
-        name: originalImage.name,
-        relativePath: newImagePath,
-        question: savedQuestion,
-        quizId: targetQuizId
-      });
-
-      const savedImage = await manager.save(QuestionImage, newImage);
-      newImageIds.push(savedImage.id);
-
-      await this.imageService.copyAndDeleteOrigin(originalImage.relativePath, newImagePath);
     }
 
     return {

--- a/apps/public/src/components/Layouts/AppLayout/index.tsx
+++ b/apps/public/src/components/Layouts/AppLayout/index.tsx
@@ -32,18 +32,19 @@ export const AppLayout: FunctionComponent<Props> = ({
   return (
     <Wrapper className="apps-container">
 
-      <MailApps 
+      <MailApps
         content={content}
         name={app.name}
         images={images}
         explanations={explanations}
         explanationNumber={explanationNumber}
         showExplanations={showExplanations}
-      />      
+      />
 
       <MessagingApps
         content={content}
         name={app.name}
+        images={images}
         explanations={explanations}
         explanationNumber={explanationNumber}
         showExplanations={showExplanations}

--- a/apps/public/src/components/Layouts/QuizLayout/components/QuizFlow/index.tsx
+++ b/apps/public/src/components/Layouts/QuizLayout/components/QuizFlow/index.tsx
@@ -15,7 +15,7 @@ import { LanguageSelect } from "../../../../UI/Select"
 import { LANG_OPTIONS } from "../../constants"
 import { useQuizRun, Answer } from '../../../../../hooks/useQuizRun'
 
-interface Props { 
+interface Props {
   quiz: any
   learnerQuiz: any
 }
@@ -31,7 +31,7 @@ export const QuizFlow: FunctionComponent<Props> = ({
   const {
     changeScene,
     scene,
-    resetAll,          
+    resetAll,
     updateUserInfo
   } = useStore(
     (state) => ({
@@ -62,71 +62,71 @@ export const QuizFlow: FunctionComponent<Props> = ({
   }
 
   return (
-      <>
-        { scene === 'welcome' && (
-          <SceneWrapper bg='white'>
+    <>
+      {scene === 'welcome' && (
+        <SceneWrapper bg='white'>
 
-            <CustomQuizNavbar color={theme.colors.green2} />
+          <CustomQuizNavbar color={theme.colors.green2} />
 
-            <CenterWrapper>
-              <GreenFishWrapper>
-                <Hooked />
-              </GreenFishWrapper>
-              <StyledBox>
-                {learnerQuiz ? (<Body1>{learnerQuiz.learnerEmail}</Body1>) : null}
-                <Heading>{quiz.title}</Heading>
-                <Body1>
-                  {t('welcome.public_message')}
-                </Body1>
-                <Buttons>
-                  <LanguageSelect
-                    onChange={(v) => {
-                      i18n.changeLanguage(v)
-                      localStorage.setItem('lang', v);
-                    }}
-                    autoselect
-                    options={LANG_OPTIONS}
-                  />
-                  <Button
-                    text={t('welcome.start')}
-                    rightIcon={<FiChevronRight size={18} />}
-                    onClick={validateQuizStart}
-                  />
-                </Buttons>
-                <LinkWrapper>
-                  <Link2 href="https://shira.app" target="_blank">
-                    {t('welcome.learn_more')}
-                  </Link2>
-                </LinkWrapper>
-              </StyledBox>
-            </CenterWrapper>
-          </SceneWrapper>
-        )}
+          <CenterWrapper>
+            <GreenFishWrapper>
+              <Hooked />
+            </GreenFishWrapper>
+            <StyledBox>
+              {learnerQuiz ? (<Body1>{learnerQuiz.learnerEmail}</Body1>) : null}
+              <Heading>{quiz.title}</Heading>
+              <Body1>
+                {t('welcome.public_message')}
+              </Body1>
+              <Buttons>
+                <LanguageSelect
+                  onChange={(v) => {
+                    i18n.changeLanguage(v)
+                    localStorage.setItem('lang', v);
+                  }}
+                  autoselect
+                  options={LANG_OPTIONS}
+                />
+                <Button
+                  text={t('welcome.start')}
+                  rightIcon={<FiChevronRight size={18} />}
+                  onClick={validateQuizStart}
+                />
+              </Buttons>
+              <LinkWrapper>
+                <Link2 href="https://shira.app" target="_blank">
+                  {t('welcome.learn_more')}
+                </Link2>
+              </LinkWrapper>
+            </StyledBox>
+          </CenterWrapper>
+        </SceneWrapper>
+      )}
 
-        { scene === 'quiz-setup-name' && (
-          <QuizSetupNameScene nextSceneSlug="custom-quiz" />
-        )}
+      {scene === 'quiz-setup-name' && (
+        <QuizSetupNameScene nextSceneSlug="custom-quiz" />
+      )}
 
-        { scene === 'custom-quiz' && (
-          <CustomQuiz
-            quizId={quiz.id}
-            questions={quiz.quizQuestions.map((q) => q.question)}
-            images={quiz.images}
-            startRun={() => {
-              start(quiz.id, learnerQuiz ? learnerQuiz.learnerId : null)
-            }}
-            recordAnswer={(qId, ans) => recordAnswer(qId, ans as Answer)}
-            runStarted={started}
-          />
-        )}
+      {scene === 'custom-quiz' && (
+        <CustomQuiz
+          quizId={quiz.id}
+          questions={quiz.quizQuestions.map((q) => q.question)}
+          images={quiz.images}
+          startRun={() => {
+            start(quiz.id, learnerQuiz ? learnerQuiz.learnerId : null)
+          }}
+          recordAnswer={(qId, ans) => recordAnswer(qId, ans as Answer)}
+          runStarted={started}
+        />
+      )}
 
-        { scene === 'completed' && (
-          <CustomQuizCompletedScene
-            quizNumber={quiz.quizQuestions.length}
-            finish={finish}
-          />
-        )}
-      </>
+      {scene === 'completed' && (
+        <CustomQuizCompletedScene
+          quizNumber={quiz.quizQuestions.length}
+          finish={finish}
+        />
+      )}
+    </>
   )
 }
 

--- a/apps/public/src/components/Layouts/QuizLayout/index.tsx
+++ b/apps/public/src/components/Layouts/QuizLayout/index.tsx
@@ -18,11 +18,11 @@ export const QuizLayout: FunctionComponent<Props> = () => {
   const [learnerQuiz, handleLearnerQuiz] = useState(null)
 
   const [showUnavailable, handleShowUnavailable] = useState(false)
-  
+
 
   const getQuiz = async (hash) => {
     let rawQuiz = null
-    
+
     try {
       if (location.pathname.includes('/learner-quiz/')) {
         const rawLearnerQuiz = await getLearnerQuizByHash(hash)
@@ -40,11 +40,11 @@ export const QuizLayout: FunctionComponent<Props> = () => {
   }
 
   useEffect(() => {
-    getQuiz(hash)    
+    getQuiz(hash)
   }, [hash])
 
   if (showUnavailable) return (
-    <InvalidLink 
+    <InvalidLink
       title={t("invalid_quiz.title")}
       description={t("invalid_quiz.description")}
       homeButtonText={t("invalid_quiz.home_button")}
@@ -54,11 +54,11 @@ export const QuizLayout: FunctionComponent<Props> = () => {
   if (!quiz) return null
 
   return (
-      <>
-        <QuizFlow 
-          quiz={quiz}
-          learnerQuiz={learnerQuiz}
-        />
-      </>
+    <>
+      <QuizFlow
+        quiz={quiz}
+        learnerQuiz={learnerQuiz}
+      />
+    </>
   )
 }

--- a/apps/public/src/components/UI/AppTypes/MessagingApps/index.tsx
+++ b/apps/public/src/components/UI/AppTypes/MessagingApps/index.tsx
@@ -11,55 +11,59 @@ interface Props {
   explanations?: Explanation[];
   explanationNumber: number;
   showExplanations: boolean
+  images?: Array<{ imageId: number; url: string }>
 }
 
-export const MessagingApps: FunctionComponent<Props> = ({ content, name, explanations, explanationNumber, showExplanations }) => {
+export const MessagingApps: FunctionComponent<Props> = ({ content, name, explanations, explanationNumber, showExplanations, images }) => {
 
   const html = new DOMParser().parseFromString(content, 'text/html')
 
-  const { parseCustomElement } = useParseHTML(content)
+  const {
+    parseCustomElement,
+    parseDynamicContent
+  } = useParseHTML(content, images)
 
   return (
     <>
-      { name === 'SMS' && (
+      {name === 'SMS' && (
         <SMS
           phone={parseCustomElement('component-required-phone')}
-          content={html.getElementById('dynamic-content')}
+          content={parseDynamicContent()}
           explanations={explanations}
           explanationNumber={explanationNumber}
           showExplanations={showExplanations}
         />
       )}
 
-      { name === 'Dating App' && (
+      {name === 'Dating App' && (
         <DatingApp
           senderName={parseCustomElement('component-required-fullname')}
-          content={html.getElementById('dynamic-content')}
+          content={parseDynamicContent()}
           explanations={explanations}
           explanationNumber={explanationNumber}
           showExplanations={showExplanations}
         />
       )}
 
-      { name === 'Whatsapp' && (
+      {name === 'Whatsapp' && (
         <Whatsapp
           phone={parseCustomElement('component-required-phone')}
-          content={html.getElementById('dynamic-content')}
+          content={parseDynamicContent()}
           explanations={explanations}
           explanationNumber={explanationNumber}
           showExplanations={showExplanations}
         />
       )}
 
-      { name === 'Messenger' && (
+      {name === 'Messenger' && (
         <FBMessenger
           senderName={parseCustomElement('component-required-fullname')}
-          content={html.getElementById('dynamic-content')}
+          content={parseDynamicContent()}
           explanations={explanations}
           explanationNumber={explanationNumber}
           showExplanations={showExplanations}
         />
       )}
-    </>    
+    </>
   )
 }

--- a/apps/public/src/hooks/useParseHTML.tsx
+++ b/apps/public/src/hooks/useParseHTML.tsx
@@ -4,6 +4,22 @@ const useParseHTML = (
 ) => {
   const html = new DOMParser().parseFromString(content, 'text/html')
 
+  const integrateImages = () => {
+    console.log('images length -> ', images.length)
+    // insert image urls
+    if (images.length > 0) {
+      html.querySelectorAll('img[data-image-id]')
+        .forEach((img) => {
+          const imgElement = images.find(i => i.imageId === parseInt(img.getAttribute('data-image-id')))
+          console.log("🚀 found image element -> ", imgElement)
+          if (imgElement) {
+            img.setAttribute("src", imgElement.url)
+          }
+        })
+    }
+
+  }
+
   const parseAttachments = () => {
     const htmlAttachments = html.querySelectorAll('[id*="component-attachment"]')
     const attachments = Array.from(htmlAttachments).map((a) => {
@@ -20,6 +36,8 @@ const useParseHTML = (
 
   const parseCustomElement = (customElement: string) => {
     const element = html.getElementById(customElement)
+    console.log("🚀 ~ parseCustomElement ~ element:", element)
+    // if element has data-image-id ? 
     const object = {
       textContent: element?.textContent || '',
       explanationPosition: element?.getAttribute('data-explanation') || null
@@ -29,22 +47,14 @@ const useParseHTML = (
   }
 
   const parseContent = (): HTMLElement => {
-    
-    // insert image urls
-    if (images.length > 0) {
-      html.querySelectorAll('img[data-image-id]')
-        .forEach((img) => {
-          const imgElement = images.find(i => i.imageId === parseInt(img.getAttribute('data-image-id')))
-          if (imgElement) {
-            img.setAttribute("src", imgElement.url)          
-          }
-        })
-    }
-      
+    integrateImages()
     return html.querySelector('[id*="component-text"]')
   }
 
-  const parseDynamicContent = () => html.getElementById('dynamic-content')
+  const parseDynamicContent = () => {
+    integrateImages()
+    return html.getElementById('dynamic-content')
+  }
 
   return {
     parseAttachments,


### PR DESCRIPTION
two issues:
1-  messaging apps werent parsing properly new image urls
2- 
When a question is duplicated, the code copies each QuestionImage record and the MinIO file, creating new records with new IDs. But the QuestionTranslation.content HTML was copied verbatim — it still had data-image-id="OLD_ID" pointing to the original image records.

The frontend uses data-image-id to match images to fresh presigned URLs. Since the IDs in the HTML didn't match the new image records, the match always failed and images couldn't be refreshed — leaving the browser to fall back on the raw src URL embedded in the HTML, which expires after 7 days.

The fix: in both duplication services, we now process images before saving translations. As each image is copied we build a map of oldId → newId. Then when saving each QuestionTranslation, we run through that map and replace every data-image-id="OLD_ID" in the content with the corresponding new ID before writing it to the database.