### PR TITLE
Add ENABLE_PUBLIC_LIBRARY flag to support self-hosted instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ cp apps/public/.env.example apps/public/.env
 cp apps/spaces/.env.example apps/spaces/.env
 ```
 
+Set `ENABLE_PUBLIC_LIBRARY=false` in `apps/api/.env` to disable the public quiz library on self-hosted instances that don't want to depend on the public library service.
+
 ## Local Development
 
 1. Install dependencies from the repo root:

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -34,5 +34,11 @@ INTERNAL_SHIRA_API_KEY=
 SHIRA_PAYMENTS_URL=
 SHIRA_LIBRARY_URL=
 
+# PUBLIC LIBRARY
+# Controls whether this instance can pull quiz/question templates from the
+# public library (SHIRA_LIBRARY_URL). Set to false on self-hosted instances
+# that don't want to depend on the public library service. Defaults to true.
+ENABLE_PUBLIC_LIBRARY=true
+
 #CORS
 COOKIE_DOMAIN=

--- a/apps/api/src/modules/quiz/exceptions/errors/quiz.error-codes.ts
+++ b/apps/api/src/modules/quiz/exceptions/errors/quiz.error-codes.ts
@@ -1,3 +1,4 @@
 export enum QuizErrorCodes {
   QuizNameAlreadyExists = 'quiz_name_already_exists',
+  PublicLibraryDisabled = 'public_library_disabled',
 }

--- a/apps/api/src/modules/quiz/exceptions/index.ts
+++ b/apps/api/src/modules/quiz/exceptions/index.ts
@@ -1,1 +1,2 @@
 export { AlreadyExistsQuizNameException } from './already-exists-name.quiz.exception';
+export { PublicLibraryDisabledException } from './public-library-disabled.quiz.exception';

--- a/apps/api/src/modules/quiz/exceptions/public-library-disabled.quiz.exception.ts
+++ b/apps/api/src/modules/quiz/exceptions/public-library-disabled.quiz.exception.ts
@@ -1,0 +1,12 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { QuizErrorCodes } from './errors/quiz.error-codes';
+
+export class PublicLibraryDisabledException extends HttpException {
+  constructor() {
+    super(
+      QuizErrorCodes.PublicLibraryDisabled,
+      HttpStatus.FORBIDDEN,
+      { cause: `Public library is disabled on this instance` },
+    );
+  }
+}

--- a/apps/api/src/modules/quiz/guards/public-library-disabled.guard.ts
+++ b/apps/api/src/modules/quiz/guards/public-library-disabled.guard.ts
@@ -1,0 +1,14 @@
+import { Injectable, CanActivate } from '@nestjs/common';
+import { PUBLIC_LIBRARY_ENABLED } from 'src/utils/environment/public-library.environment';
+import { PublicLibraryDisabledException } from '../exceptions';
+
+@Injectable()
+export class PublicLibraryDisabledGuard implements CanActivate {
+  canActivate(): boolean {
+    if (!PUBLIC_LIBRARY_ENABLED) {
+      throw new PublicLibraryDisabledException();
+    }
+
+    return true;
+  }
+}

--- a/apps/api/src/modules/quiz/template/create-template.quiz.controller.ts
+++ b/apps/api/src/modules/quiz/template/create-template.quiz.controller.ts
@@ -11,6 +11,7 @@ import { CachedSubscription } from "src/modules/subscription/dto/cached-response
 import { IValidateCreateQuizService } from "../interfaces/services/validate-create.quiz.service.interface";
 import { CreateTemplateQuizDto } from "./create-template.quiz.dto";
 import { ICreateTemplateQuizService } from "./create-template.quiz.service.interface";
+import { PublicLibraryDisabledGuard } from "../guards/public-library-disabled.guard";
 
 @AuthController("quiz-from-template")
 export class CreateTemplateQuizController {
@@ -23,7 +24,7 @@ export class CreateTemplateQuizController {
 
   @Post()
   @Roles(Role.SpaceAdmin)
-  @UseGuards(SubscriptionGuard)
+  @UseGuards(SubscriptionGuard, PublicLibraryDisabledGuard)
   async create(
     @LoggedUser() user: LoggedUserDto,
     @Body() createTemplateQuizDto: CreateTemplateQuizDto,

--- a/apps/api/src/modules/subscription/controller/get-subscription.controller.ts
+++ b/apps/api/src/modules/subscription/controller/get-subscription.controller.ts
@@ -6,6 +6,7 @@ import { LoggedUser } from "src/modules/auth/decorators";
 import { LoggedUserDto } from "src/modules/user/dto/logged.user.dto";
 import { Roles } from "src/modules/auth/decorators/roles.decorators";
 import { Role } from "src/modules/user/domain/role.enum";
+import { PUBLIC_LIBRARY_ENABLED } from "src/utils/environment/public-library.environment";
 
 @AuthController('subscription')
 export class GetSubscriptionController {
@@ -19,6 +20,8 @@ export class GetSubscriptionController {
   async handler(
     @LoggedUser() user: LoggedUserDto,
   ) {
-    return await this.subscriptionCacheService.getCurrentSubscription(String(user.activeOrganization.id), user.activeSpace.space.id);
+    const subscription = await this.subscriptionCacheService.getCurrentSubscription(String(user.activeOrganization.id), user.activeSpace.space.id);
+
+    return { ...subscription, publicLibraryEnabled: PUBLIC_LIBRARY_ENABLED };
   }
 }

--- a/apps/api/src/modules/user/controllers/me.user.controller.ts
+++ b/apps/api/src/modules/user/controllers/me.user.controller.ts
@@ -10,6 +10,7 @@ import { IMarkUserLoginService } from '../interfaces/services/mark.user.login.se
 import { SubscriptionGuard } from 'src/modules/subscription/guards/subscription.guard';
 import { SubscriptionDecorator } from 'src/modules/subscription/decorators/subscription.decorator';
 import { CachedSubscription } from 'src/modules/subscription/dto/cached-response.dto';
+import { PUBLIC_LIBRARY_ENABLED } from 'src/utils/environment/public-library.environment';
 
 @AuthController('user')
 export class MeUserController {
@@ -24,11 +25,11 @@ export class MeUserController {
   async me(
     @LoggedUser() user: LoggedUserDto,
     @SubscriptionDecorator() subscription: Partial<CachedSubscription>
-  ) {    
+  ) {
     await this.markUserLoginService.execute(user.id);
     return {
       user,
-      subscription
+      subscription: { ...subscription, publicLibraryEnabled: PUBLIC_LIBRARY_ENABLED }
     }
   }
 }

--- a/apps/api/src/utils/environment/public-library.environment.ts
+++ b/apps/api/src/utils/environment/public-library.environment.ts
@@ -1,0 +1,4 @@
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+export const PUBLIC_LIBRARY_ENABLED: boolean = process.env.ENABLE_PUBLIC_LIBRARY !== 'false';

--- a/apps/spaces/src/components/DashboardLayout/index.tsx
+++ b/apps/spaces/src/components/DashboardLayout/index.tsx
@@ -20,6 +20,7 @@ import { getCurrentDateFNSLocales } from "../../language/dateUtils";
 import { useQuizCreationFlow } from "../../hooks/useQuizCreationFlow";
 import { CreateQuizButton } from "./components/CreateQuizButton";
 import { useSub } from "../../hooks/useSub";
+import { usePublicLibrary } from "../../hooks/usePublicLibrary";
 import { CheckoutSuccessModal } from "../modals/CheckoutSuccessModal";
 import { QuizLimitModal } from "../modals/QuizLimitModal";
 import { ViewPlansModal } from "../modals/ViewPlansModal";
@@ -89,6 +90,7 @@ export const DashboardLayout: FunctionComponent<Props> = () => {
     })));
 
   const { isSubActive } = useSub()
+  const { isPublicLibraryEnabled } = usePublicLibrary()
 
   const [activeFilter, setActiveFilter] = useState<FilterStates>(FilterStates.all);
   const [cards, setCards] = useState([]);
@@ -301,6 +303,7 @@ export const DashboardLayout: FunctionComponent<Props> = () => {
               <UseAQuizTemplateButton
                 isSubActive={isSubActive}
                 quizCount={quizzes ? quizzes.length : 0}
+                disabled={!isPublicLibraryEnabled}
                 onLimitReached={() => setIsQuizLimitModalOpen(true)}
               />
             </HeaderActions>

--- a/apps/spaces/src/components/QuestionLibraryListLayout/index.tsx
+++ b/apps/spaces/src/components/QuestionLibraryListLayout/index.tsx
@@ -21,6 +21,7 @@ import type { RowType } from "./components/Columns";
 import { questionTemplateToRow } from "./components/Columns/questionTemplateToRow";
 import { useTranslation } from "react-i18next";
 import { useQuestionTemplateList } from "./hooks/useQuestionTemplateList";
+import { usePublicLibrary } from "../../hooks/usePublicLibrary";
 import { QuestionTemplateControls } from "./components/QuestionTemplateControls";
 import { QuestionTemplateFilters } from "./components/QuestionTemplateFilters";
 import { QuestionTemplateResults } from "./components/QuestionTemplateResults";
@@ -44,6 +45,13 @@ export const QuestionLibraryListLayout: FunctionComponent = () => {
   );
 
   const { t } = useTranslation();
+  const { isPublicLibraryEnabled } = usePublicLibrary();
+
+  useEffect(() => {
+    if (!isPublicLibraryEnabled) {
+      navigate("/dashboard", { replace: true });
+    }
+  }, [isPublicLibraryEnabled, navigate]);
 
   const [preview, setPreview] = useState<RowType | null>(null);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});

--- a/apps/spaces/src/components/QuizLibraryListLayout/components/UseAQuizTemplateButton/index.tsx
+++ b/apps/spaces/src/components/QuizLibraryListLayout/components/UseAQuizTemplateButton/index.tsx
@@ -7,12 +7,14 @@ import { useNavigate } from "react-router-dom";
 interface Props {
   isSubActive: boolean
   quizCount: number
+  disabled?: boolean
   onLimitReached?: () => void
 }
 
 export const UseAQuizTemplateButton: FunctionComponent<Props> = ({
   quizCount,
   isSubActive,
+  disabled,
   onLimitReached,
 }) => {
   const theme = useTheme();
@@ -37,6 +39,7 @@ export const UseAQuizTemplateButton: FunctionComponent<Props> = ({
         leftIcon={<MdOutlineMenuBook />}
         text={t('dashboard.use_a_quiz_template_button')}
         onClick={handleClick}
+        disabled={disabled}
         color={theme.colors.green7}
       />
     </ButtonContainer>

--- a/apps/spaces/src/components/QuizLibraryListLayout/index.tsx
+++ b/apps/spaces/src/components/QuizLibraryListLayout/index.tsx
@@ -16,6 +16,7 @@ import { QuizLimitModal } from "../modals/QuizLimitModal";
 import { ViewPlansModal } from "../modals/ViewPlansModal";
 import { QuizLibraryPreviewModal } from "../modals/QuizLibraryPreviewModal";
 import { useSub } from "../../hooks/useSub";
+import { usePublicLibrary } from "../../hooks/usePublicLibrary";
 import { QuizLibraryFlowManagement } from "../QuizLibraryFlowManagement";
 import { useQuizTemplateList } from "./hooks/useQuizTemplateList";
 import { LibrarySearchEmptyState } from "../LibrarySearchEmptyState";
@@ -44,6 +45,14 @@ export const QuizTemplatesListLayout: FunctionComponent = () => {
   }), shallow);
 
   const { isSubActive } = useSub();
+  const { isPublicLibraryEnabled } = usePublicLibrary();
+
+  useEffect(() => {
+    if (!isPublicLibraryEnabled) {
+      navigate("/dashboard", { replace: true });
+    }
+  }, [isPublicLibraryEnabled, navigate]);
+
   const {
     areFiltersOpen,
     debouncedSearchValue,

--- a/apps/spaces/src/components/QuizViewLayout/components/QuestionEmptyState.tsx
+++ b/apps/spaces/src/components/QuizViewLayout/components/QuestionEmptyState.tsx
@@ -8,12 +8,14 @@ interface Props {
   onAdd: () => void,
   onAddLibrary: (quizId: string) => void,
   quizId: string,
+  isAddLibraryDisabled?: boolean,
 }
 
 export const QuestionEmptyState: FunctionComponent<Props> = ({
   onAdd,
   onAddLibrary,
   quizId,
+  isAddLibraryDisabled,
 }) => {
 
   const { t } = useTranslation();
@@ -33,6 +35,7 @@ export const QuestionEmptyState: FunctionComponent<Props> = ({
       text={t('questions_tab.use_library_question_button')}
       type="primary"
       color={defaultTheme.colors.green7}
+      disabled={isAddLibraryDisabled}
       onClick={() => onAddLibrary(quizId)}
     />
   ];

--- a/apps/spaces/src/components/QuizViewLayout/components/QuestionList.tsx
+++ b/apps/spaces/src/components/QuizViewLayout/components/QuestionList.tsx
@@ -11,6 +11,7 @@ import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { duplicateQuestion } from "../../../fetch/quiz";
 import { useStore } from "../../../store";
+import { usePublicLibrary } from "../../../hooks/usePublicLibrary";
 import { QuizQuestion } from "../../../store/slices/quiz";
 import { DeleteModal } from "../../modals/DeleteModal";
 import { QuizHasResultsModal } from "../../modals/QuizHasResultsModal";
@@ -46,6 +47,7 @@ export const QuestionsList: FunctionComponent<QuestionsListProps> = ({
   hasResults
 }) => {
   const { t } = useTranslation();
+  const { isPublicLibraryEnabled } = usePublicLibrary();
 
   const [questionForDelete, handleQuestionForDelete] = useState<QuizQuestion["question"] | null>(null);
   const [confirmBeforeContinueModal, handleConfirmBeforeContinueModal] = useState<{
@@ -89,6 +91,7 @@ export const QuestionsList: FunctionComponent<QuestionsListProps> = ({
         onAdd={onAdd}
         onAddLibrary={onAddLibrary}
         quizId={String(quizId)}
+        isAddLibraryDisabled={!isPublicLibraryEnabled}
       />
     );
   }
@@ -119,6 +122,7 @@ export const QuestionsList: FunctionComponent<QuestionsListProps> = ({
           text={t("questions_tab.use_library_question_button")}
           type="primary"
           color={defaultTheme.colors.green7}
+          disabled={!isPublicLibraryEnabled}
           onClick={() => onAddLibrary(quizId.toString())}
         />
       </Header>

--- a/apps/spaces/src/hooks/usePublicLibrary.tsx
+++ b/apps/spaces/src/hooks/usePublicLibrary.tsx
@@ -1,0 +1,15 @@
+import { useStore } from "../store";
+import { shallow } from "zustand/shallow";
+
+export const usePublicLibrary = () => {
+
+  const {
+    isPublicLibraryEnabled,
+  } = useStore((state) => ({
+    isPublicLibraryEnabled: state.publicLibraryEnabled,
+  }), shallow)
+
+  return {
+    isPublicLibraryEnabled
+  };
+};

--- a/apps/spaces/src/store/slices/auth.ts
+++ b/apps/spaces/src/store/slices/auth.ts
@@ -25,6 +25,7 @@ export interface AuthSlice {
     type: string;
     organizationId: string;
   }
+  publicLibraryEnabled: boolean;
   fetching: boolean;
 }
 
@@ -47,6 +48,7 @@ export const createAuthSlice: StateCreator<
   user: null,
   space: null,
   subscription: null,
+  publicLibraryEnabled: true,
   fetching: true,
   loginStatus: 'idle',
   setLoginStatus: (status) => set({ loginStatus: status }),
@@ -60,6 +62,7 @@ export const createAuthSlice: StateCreator<
         user: user,
         space: user.spaces[0],
         subscription: sub,
+        publicLibraryEnabled: Boolean(sub?.publicLibraryEnabled),
         loginStatus: 'success'
       })
     } catch (e) {
@@ -72,7 +75,8 @@ export const createAuthSlice: StateCreator<
     set({
       user: null,
       space: null,
-      subscription: null
+      subscription: null,
+      publicLibraryEnabled: true
     })
     if (navigate) {
       navigate('/login')
@@ -94,7 +98,8 @@ export const createAuthSlice: StateCreator<
       set({
         user: res.user,
         space: res.user.activeSpace.space,
-        subscription: res.subscription
+        subscription: res.subscription,
+        publicLibraryEnabled: Boolean(res.subscription?.publicLibraryEnabled)
       });
     } else if (!isPublicRoute(window.location.pathname)) {
       window.location.href = '/login';


### PR DESCRIPTION
Introduces an `ENABLE_PUBLIC_LIBRARY` env flag (default true) that lets self-hosted instances disable the public quiz/question library.

- API: exposes `publicLibraryEnabled` via the `/me` and `subscription` endpoints, adds a guard or exception to block library routes when disabled
- Spaces: adds a `usePublicLibrary` hook, stores the flag in the auth slice, disables library buttons (quiz templates, question library) and redirects away from library routes when disabled
- README: documents the new env var