### PR TITLE
fix: add highlight for the entire attachment when there's an explanation

### DIFF
--- a/packages/shira-ui/src/components/Apps/DatingApp/Chat/Attachment/index.tsx
+++ b/packages/shira-ui/src/components/Apps/DatingApp/Chat/Attachment/index.tsx
@@ -10,9 +10,9 @@ export const Attachment: FunctionComponent<Props> = ({ name, explanationPosition
 
   return (
     <Wrapper>
-      <Content>
+      <Content data-explanation={explanationPosition}>
         <SvgWrapper><Document /></SvgWrapper>
-        <span data-explanation={explanationPosition}>
+        <span>
           { name }
         </span>
       </Content>

--- a/packages/shira-ui/src/components/Apps/Gmail/Attachment/index.tsx
+++ b/packages/shira-ui/src/components/Apps/Gmail/Attachment/index.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react'
 import styled from 'styled-components'
-import { 
+import {
   ImageIcon,
   VideoIcon,
   AudioIcon,
@@ -23,7 +23,7 @@ export const Attachment: FunctionComponent<Props> = ({
 }) => {
 
   const renderSwitch = (type: string) => {
-    switch(type) {
+    switch (type) {
       case AttachmentType.audio:
         return <AudioIcon />
       case AttachmentType.document:
@@ -35,17 +35,17 @@ export const Attachment: FunctionComponent<Props> = ({
       case AttachmentType.other:
         return <GenericAttachmentIcon />
       default:
-        return <GenericAttachmentIcon/>
+        return <GenericAttachmentIcon />
     }
   }
 
-    
+
   return (
-    <Wrapper>
+    <Wrapper data-explanation={explanationPosition}>
       <Hovered>
-        <Name>      
+        <Name>
           <IconWrapper size={16} color='#15c'>
-            { renderSwitch(type) }        
+            {renderSwitch(type)}
           </IconWrapper>
           <span>
             {name}
@@ -55,16 +55,14 @@ export const Attachment: FunctionComponent<Props> = ({
       <div>
         <Preview>
           <IconWrapper size={34}>
-            { renderSwitch(type) }        
+            {renderSwitch(type)}
           </IconWrapper>
         </Preview>
-        <Name>      
+        <Name>
           <IconWrapper size={16} color='#15c'>
-            { renderSwitch(type) }        
+            {renderSwitch(type)}
           </IconWrapper>
-          <span 
-            data-explanation={explanationPosition} 
-          >
+          <span>
             {name}
           </span>
         </Name>

--- a/packages/shira-ui/src/components/Apps/Outlook/Attachment/index.tsx
+++ b/packages/shira-ui/src/components/Apps/Outlook/Attachment/index.tsx
@@ -17,14 +17,14 @@ interface Props {
 
 const randomSize = Math.floor(Math.random() * 300) + 1
 
-export const Attachment:FunctionComponent<Props> = ({
+export const Attachment: FunctionComponent<Props> = ({
   name,
   explanationPosition,
   type
 }) => {
 
   const renderSwitch = (type: string) => {
-    switch(type) {
+    switch (type) {
       case AttachmentType.audio:
         return <AudioIcon />
       case AttachmentType.document:
@@ -36,20 +36,17 @@ export const Attachment:FunctionComponent<Props> = ({
       case AttachmentType.other:
         return <GenericAttachmentIcon />
       default:
-        return <GenericAttachmentIcon/>
+        return <GenericAttachmentIcon />
     }
   }
-  
+
   return (
-    <Wrapper>
+    <Wrapper data-explanation={explanationPosition}>
       <Left>
         <SvgWrapper> {renderSwitch(type)} </SvgWrapper>
         <TextWrapper>
-          <Name 
-            data-explanation={explanationPosition} 
-            title={name}
-          >
-            { name }
+          <Name title={name}>
+            {name}
           </Name>
           <Size>{randomSize} KB</Size>
         </TextWrapper>

--- a/packages/shira-ui/src/components/Apps/SMS/Attachment/index.tsx
+++ b/packages/shira-ui/src/components/Apps/SMS/Attachment/index.tsx
@@ -12,13 +12,13 @@ export const Attachment: FunctionComponent<Props> = ({ name, explanationPosition
   return (
     <Wrapper>
       <Pic />
-      <Content>
+      <Content data-explanation={explanationPosition}>
         <SvgWrapper><Document /></SvgWrapper>
-        <span data-explanation={explanationPosition}>
-          { name }
+        <span>
+          {name}
         </span>
       </Content>
-    </Wrapper>    
+    </Wrapper>
   )
 }
 

--- a/packages/shira-ui/src/components/Apps/Whatsapp/MessageWrapper/components/Attachment/index.tsx
+++ b/packages/shira-ui/src/components/Apps/Whatsapp/MessageWrapper/components/Attachment/index.tsx
@@ -12,19 +12,19 @@ export const Attachment: FunctionComponent<Props> = ({ name, explanationPosition
 
   return (
     <Wrapper>
-        <Card>
-          <div>
-            <ImageWrapper src={Document}/>
-            <Name data-explanation={explanationPosition}>
-              { name }
-            </Name>
-            <Download>
-              <DownloadIcon />
-            </Download>
-          </div>
-          <span>00:00</span>
-        </Card>
-    </Wrapper>    
+      <Card data-explanation={explanationPosition}>
+        <div>
+          <ImageWrapper src={Document} />
+          <Name>
+            {name}
+          </Name>
+          <Download>
+            <DownloadIcon />
+          </Download>
+        </div>
+        <span>00:00</span>
+      </Card>
+    </Wrapper>
   )
 }
 


### PR DESCRIPTION
### Task
https://app.asana.com/1/1155076882573518/project/1201968080212131/task/1213181341534353?focus=true